### PR TITLE
fix: prevent default project duplication when name is empty

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -72,7 +72,7 @@ namespace Data_Logger_1._3
                     //    Password = key
                     //}.ToString();
 
-                    service.AddDbContext<ENTITYMASTER>(options =>
+                    service.AddDbContext<EntityMaster>(options =>
                     {
                         options.UseSqlite(context.Configuration.GetConnectionString("DefaultConnection"))
                         .LogTo(Console.WriteLine, LogLevel.Information);
@@ -83,9 +83,9 @@ namespace Data_Logger_1._3
                     });
 
                     service.AddSingleton<Cachemaster>();
-                    service.AddScoped((services) => new ENTITYREADER(services));
-                    service.AddScoped((services) => new ENTITYWRITER(services));
-                    service.AddScoped((services) => new ENTITYHANDLER(services));
+                    service.AddScoped((services) => new EntityReader(services));
+                    service.AddScoped((services) => new EntityWriter(services));
+                    service.AddScoped((services) => new EntityHandler(services));
 
                     service.AddSingleton((services) => new AuthService(services));
 
@@ -227,7 +227,7 @@ namespace Data_Logger_1._3
             using (var scope = _serviceProvider.CreateScope())
             {
                 await AnimateProgressBar(splash.progressBar_splashscreen, 75, splash.text_progress);
-                var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+                var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
                 await AnimateProgressBar(splash.progressBar_splashscreen, 80, splash.text_progress);
 
                 // Ensure DB exists

--- a/Commands/LoggerCommands/AnnotateCommand.cs
+++ b/Commands/LoggerCommands/AnnotateCommand.cs
@@ -136,6 +136,7 @@ namespace Data_Logger_1._3.Commands.LoggerCommands
                 {
                     application = new();
                     application.appID = 3;
+                    application.Name = "Unknown";
                 }
                 else
                     application = ActionType == ActionType.Add ? new(account,

--- a/Commands/LoggerCommands/AnnotateCommand.cs
+++ b/Commands/LoggerCommands/AnnotateCommand.cs
@@ -125,18 +125,25 @@ namespace Data_Logger_1._3.Commands.LoggerCommands
 
                 List<PostIt> posts = new();
 
+                // Add: Create a new application using the form's application name.
+                // Edit: Don't create a new appliccation. The application is handled later on in the switch statement.
+                ApplicationClass? application;
+
                 // Manage Application name if it is empty.
                 if (string.IsNullOrEmpty(_viewModel.ApplicationName) ||
                     _viewModel.ApplicationName.Equals("Unknown", StringComparison.OrdinalIgnoreCase) ||
                     _viewModel.ApplicationName.Equals("Unknown Application", StringComparison.OrdinalIgnoreCase))
                 {
-                    _viewModel.ApplicationName = "Unknown";
+                    application = new();
+                    application.appID = 3;
                 }
-
-                // Add: Create a new application using the form's application name.
-                // Edit: Don't create a new appliccation. The application is handled later on in the switch statement.
-                ApplicationClass? application = ActionType == ActionType.Add ? new(account,
+                else
+                    application = ActionType == ActionType.Add ? new(account,
                         _viewModel.ApplicationName, _viewModel.Category, false) : null;
+
+
+                // Add:
+                ProjectClass? project;
 
                 // Manage Project name if it is empty.
                 if (string.IsNullOrEmpty(_viewModel.ProjectName) ||
@@ -144,11 +151,23 @@ namespace Data_Logger_1._3.Commands.LoggerCommands
                     _viewModel.ProjectName.Equals("Unknown", StringComparison.OrdinalIgnoreCase) ||
                     _viewModel.ProjectName.Equals("Unknown Project", StringComparison.OrdinalIgnoreCase))
                 {
-                    _viewModel.ProjectName = "Unnamed Project";
+                    project = new();
+                    project.projectID = 1;
+                    project.Name = "Unnamed Project";
+                }
+                else
+                {
+                    project = new(account, _viewModel.ProjectName, application, _viewModel.Category, false);
+
+                    if (application == null)
+                        project.appID = 3;
                 }
 
-                // Add:
-                ProjectClass? project = new(account, _viewModel.ProjectName, application, _viewModel.Category, false);
+                if (application?.appID == 3)
+                {
+                    project.appID = 3;
+                    project.Application = null;
+                }
 
                 OutputClass? output = new(account, _viewModel.Output, application, _viewModel.Category);
                 TypeClass? type = new(account, _viewModel.Type, application, _viewModel.Category);

--- a/Commands/ReporterCommands/UpdateCommands/UpdateCommand.cs
+++ b/Commands/ReporterCommands/UpdateCommands/UpdateCommand.cs
@@ -59,36 +59,75 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
 
                 bool appIsNew = false;
 
+                // APPLICATION
+
                 if (string.IsNullOrEmpty(_editor.ApplicationName))
                 {
-                    _log.Application = await _dataService.FindApplication(userID, "Unknown") ?? new(1, "Unknown");
+                    // Set to "Unknown" default
+                    _log.appID = 3;
+                    _log.Application = null;
                 }
                 else if (_log.Application.Name != _editor.ApplicationName)
                 {
-                    var app = await _dataService.FindApplication(userID, _editor.ApplicationName) ?? new(account, _editor.ApplicationName);
+                    // App may be the same or changed. Changed app may be new or existing
+                    var app = await _dataService.FindApplication(userID, _editor.ApplicationName);
+
+                    if(app == null)
+                    {
+                        app = new ApplicationClass(_editor.ApplicationName);
+                        app.accountID = _log.accountID;                    
+                    }
+                        
                     appIsNew = app.appID == 0;
 
-                    _log.Application = app;
+                    if (appIsNew)
+                        _log.Application = app;
+                    else
+                    {
+                        _log.appID = app.appID;
+                        _log.Application = null;
+                    }
                 }
+
+
+
+                // PROJECT
 
                 if (!appIsNew)
                 {
+                    bool projectBelongsToNewApp = _log.Project.appID == _log.appID;
+
                     if (string.IsNullOrEmpty(_editor.ProjectName))
                     {
-                        _log.Project = await _dataService.FindProject(userID, "Unnamed Project", 3) ?? new("Unnamed Project");
+                        // Set to "Unnamed Project" default
+                        _log.projectID = 1;
+                        _log.Project = null;
                     }
-                    else if (_log.Project.Name != _editor.ProjectName)
+                    else if (_log.Project.Name != _editor.ProjectName || !projectBelongsToNewApp)
                     {
-                        var project = await _dataService.FindProject(account.accountID, _editor.ProjectName, _log.Application.appID)
-                            ?? new(account, _editor.ProjectName, _log.Application);
-                        _log.Project = project;
+                        var project = await _dataService.FindProject(account.accountID, _editor.ProjectName, _log.appID);
+
+                        if (project == null)
+                        {
+                            project = new ProjectClass(_editor.ProjectName);
+                            project.accountID = account.accountID;
+                            project.appID = _log.appID;
+                        }
+
+                        if (project.projectID == 0)
+                            _log.Project = project;
+                        else
+                        {
+                            _log.projectID = project.projectID;
+                            _log.Project = null;
+                        }
                     }
                 }
                 else
                 {
-                    var project = new ProjectClass(account, _editor.ProjectName, _log.Application);
-                    _log.Project = project;
+                    _log.Project = new ProjectClass(account, _editor.ProjectName, _log.Application!);
                 }
+
 
                 _log.Start = _editor.StartDate;
                 _log.End = _editor.EndDate;
@@ -114,9 +153,7 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                         subject = new(
                                       _log.Category,
                                       account,
-                                      editorPostIt.Subject,
-                                      _log.Project,
-                                      _log.Application);
+                                      editorPostIt.Subject);
                     }
 
 
@@ -128,6 +165,7 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                         {
                             newPostIt = new PostIt
                             {
+                                // Both PostIt and Subject is NEW
                                 Subject = subject,
                                 Error = editorPostIt.Error,
                                 ERCaptureTime = editorPostIt.DateFound,
@@ -141,6 +179,7 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                         }
                         else
                         {
+                            // PostIt is NEW, Subject EXISTS
                             newPostIt = new PostIt
                             {
                                 subjectID = subject.subjectID,
@@ -161,9 +200,18 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                     {
                         var existingPostIt = _log.PostItList.First(p => p.postItID == editorPostIt.ID);
 
+                        // existingPostIt.Subject is NOT null here
 
-                        existingPostIt.subjectID = subject.subjectID;
-                        existingPostIt.Subject = subject;
+                        if (subjectIsNew)
+                        {
+                            // PostIt Exists, Subject is NEW
+                            existingPostIt.Subject = subject;
+                        }
+                        else
+                        {
+                            // PostIt Exists, Subject Exists
+                            existingPostIt.subjectID = subject.subjectID;
+                        }
 
                         existingPostIt.Error = editorPostIt.Error;
                         existingPostIt.ERCaptureTime = editorPostIt.DateFound;

--- a/Migrations/20251127115837_Alpha3InitialMigration.Designer.cs
+++ b/Migrations/20251127115837_Alpha3InitialMigration.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Data_Logger_1._3.Migrations
 {
-    [DbContext(typeof(ENTITYMASTER))]
+    [DbContext(typeof(EntityMaster))]
     [Migration("20251127115837_Alpha3InitialMigration")]
     partial class Alpha3InitialMigration
     {

--- a/Migrations/20251128151754_AddVisualStudioCodeApp.Designer.cs
+++ b/Migrations/20251128151754_AddVisualStudioCodeApp.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Data_Logger_1._3.Migrations
 {
-    [DbContext(typeof(ENTITYMASTER))]
+    [DbContext(typeof(EntityMaster))]
     [Migration("20251128151754_AddVisualStudioCodeApp")]
     partial class AddVisualStudioCodeApp
     {

--- a/Migrations/ENTITYMASTERModelSnapshot.cs
+++ b/Migrations/ENTITYMASTERModelSnapshot.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Data_Logger_1._3.Migrations
 {
-    [DbContext(typeof(ENTITYMASTER))]
+    [DbContext(typeof(EntityMaster))]
     partial class ENTITYMASTERModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)

--- a/Models/App Models/SubjectClass.cs
+++ b/Models/App Models/SubjectClass.cs
@@ -41,6 +41,13 @@ namespace Data_Logger_1._3.Models.App_Models
             Subject = subjectName;
         }
 
+        public SubjectClass(LOG.CATEGORY category, ACCOUNT user, string subject)
+        {
+            Category = category;
+            accountID = user.accountID;
+            Subject = subject;
+        }
+
         public SubjectClass(int subjectID, LOG.CATEGORY category, ACCOUNT user, string subject, ProjectClass project, ApplicationClass application)
         {
             this.subjectID = subjectID;

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -44,7 +44,7 @@ namespace Data_Logger_1._3.Services
                 }
                 catch (Exception ex)
                 {
-                    var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                    var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                     await writer.HandleExceptionAsync(ex, "SignUp(dp,email,password,displayName,surname,isEmployee,companyName,companyAddress,companyLogo)");
                 }
 
@@ -54,7 +54,7 @@ namespace Data_Logger_1._3.Services
 
             try
             {
-                var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                 await writer.UnsetCurrentUser();
 
                 var account = new ACCOUNT
@@ -82,7 +82,7 @@ namespace Data_Logger_1._3.Services
             }
             catch (Exception ex)
             {
-                var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                 await writer.HandleExceptionAsync(ex, "SignUp(dp,email,password,displayName,surname,isEmployee,companyName,companyAddress,companyLogo)");
 
                 MessageBox.Show("A problem occurred on our end. We apologise for any inconvenience caused. Feedback will automatically be sent to us.",

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -291,12 +291,12 @@ namespace Data_Logger_1._3.Services
         public async Task<List<SubjectClass>?> ListSubjects(ProjectClass project)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             try
             {
-                var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+                var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
                 return await reader.ListSubjects(project);
             }
             catch (InvalidOperationException invex)
@@ -318,12 +318,12 @@ namespace Data_Logger_1._3.Services
         public async Task<List<OutputClass>?> ListQtOutputs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             try
             {
-                var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+                var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
                 return await reader.ListQtOutputs();
             }
             catch (InvalidOperationException invex)
@@ -345,12 +345,12 @@ namespace Data_Logger_1._3.Services
         public async Task<List<OutputClass>?> ListASOutputs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             try
             {
-                var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+                var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
                 return await reader.ListASOutputs();
             }
             catch (InvalidOperationException invex)
@@ -373,12 +373,12 @@ namespace Data_Logger_1._3.Services
         public async Task<List<OutputClass>?> ListOutputs(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             try
             {
-                var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+                var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
                 return await reader.ListOutputs(category);
             }
             catch (InvalidOperationException invex)
@@ -402,12 +402,12 @@ namespace Data_Logger_1._3.Services
         public async Task<List<TypeClass>?> ListQtTypes()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             try
             {
-                var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+                var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
                 return await reader.ListQtTypes();
             }
             catch (InvalidOperationException invex)
@@ -429,12 +429,12 @@ namespace Data_Logger_1._3.Services
         public async Task<List<TypeClass>?> ListASTypes()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             try
             {
-                var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+                var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
                 return await reader.ListASTypes();
             }
             catch (InvalidOperationException invex)
@@ -457,12 +457,12 @@ namespace Data_Logger_1._3.Services
         public async Task<List<TypeClass>?> ListTypes(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             try
             {
-                var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+                var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
                 return await reader.ListTypes(category);
             }
             catch (InvalidOperationException invex)
@@ -487,13 +487,13 @@ namespace Data_Logger_1._3.Services
 
 
         /// <summary>
-        /// Executes a function with an ENTITYREADER instance, managing scope and exceptions.
+        /// Executes a function with an EntityReader instance, managing scope and exceptions.
         /// </summary>
-        private async Task<T> UseReaderAsync<T>(Func<ENTITYREADER, Task<T>> func)
+        private async Task<T> UseReaderAsync<T>(Func<EntityReader, Task<T>> func)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -512,12 +512,12 @@ namespace Data_Logger_1._3.Services
         }
 
         /// <summary>
-        /// Executes a function with an ENTITYWRITER instance, managing scope and exceptions.
+        /// Executes a function with an EntityWriter instance, managing scope and exceptions.
         /// </summary>
-        private async Task<T> UseWriterAsync<T>(Func<ENTITYWRITER, Task<T>> func)
+        private async Task<T> UseWriterAsync<T>(Func<EntityWriter, Task<T>> func)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -536,13 +536,13 @@ namespace Data_Logger_1._3.Services
         }
 
         /// <summary>
-        /// Executes a function with an ENTITYHANDLER instance, managing scope and exceptions.
+        /// Executes a function with an EntityHandler instance, managing scope and exceptions.
         /// </summary>
-        private async Task<T> UseHandlerAsync<T>(Func<ENTITYHANDLER, Task<T>> func)
+        private async Task<T> UseHandlerAsync<T>(Func<EntityHandler, Task<T>> func)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var handler = scope.ServiceProvider.GetRequiredService<ENTITYHANDLER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var handler = scope.ServiceProvider.GetRequiredService<EntityHandler>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1058,7 +1058,7 @@ namespace Data_Logger_1._3.Services
         public async Task HandleExceptionAsync(Exception exception, string methodName, string exceptionType = "Exception")
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
 
             await writer.HandleExceptionAsync(exception, methodName, exceptionType);

--- a/Services/ENTITYHANDLER.cs
+++ b/Services/ENTITYHANDLER.cs
@@ -51,15 +51,13 @@ namespace Data_Logger_1._3.Services
                     .Include(l => l.Type)
                     .Include(l => l.PostItList)
                         .ThenInclude(p => p.Subject)
-                        .FirstOrDefaultAsync(l => l.ID == log.ID);
+                    .FirstOrDefaultAsync(l => l.ID == log.ID);
 
                 if (existingLog == null)
-                    throw new InvalidOperationException("Cannot update a log that doesn't exist.");
+                    throw new ArgumentNullException("Cannot update a log that doesn't exist.");
 
-                // 2️ Update scalar/primitive properties
                 master.Entry(existingLog).CurrentValues.SetValues(log);
 
-                // 3️ Update navigation properties safely
                 if (log.Application != null)
                     existingLog.Application = master.Applications.Local
                         .FirstOrDefault(a => a.appID == log.Application.appID) ?? log.Application;
@@ -72,67 +70,79 @@ namespace Data_Logger_1._3.Services
                     existingLog.Output = master.Outputs.Local
                         .FirstOrDefault(o => o.outputID == log.Output.outputID) ?? log.Output;
 
-                if(log.Type != null)
+                if (log.Type != null)
                     existingLog.Type = master.Types.Local
                         .FirstOrDefault(t => t.typeID == log.Type.typeID) ?? log.Type;
 
-                var incomingIds = log.PostItList.Where(p => p.postItID != 0).Select(p => p.postItID).ToHashSet();
+                var incomingIds = log.PostItList
+                    .Where(p => p.postItID != 0)
+                    .Select(p => p.postItID)
+                    .ToHashSet();
 
-                // Remove PostIts that were deleted
+                // REMOVE
                 foreach (var postIt in existingLog.PostItList.ToList())
                 {
                     if (!incomingIds.Contains(postIt.postItID))
                     {
                         master.PostIts.Remove(postIt);
-                        await master.SaveChangesAsync();
                     }
                 }
 
-                // Add or update incoming PostIts
+                // ADD + UPDATE
                 foreach (var postIt in log.PostItList)
                 {
                     if (postIt.postItID == 0)
                     {
-                        // New PostIt added to the log
-                        if(postIt.Subject != null)
-                        {
-                            postIt.Subject.Application = existingLog.Application;
-                            postIt.Subject.Project = existingLog.Project;
-                        }
-                        
+                        // resolve subject
+                        var trackedSubject = master.Subjects.Local
+                            .FirstOrDefault(s => s.subjectID == postIt.subjectID) ?? postIt.Subject;
 
-                        existingLog.PostItList.Add(postIt);
+                        // create new entity
+                        var newPostIt = new PostIt
+                        {
+                            Error = postIt.Error,
+                            Solution = postIt.Solution,
+                            Suggestion = postIt.Suggestion,
+                            Comment = postIt.Comment,
+                            ERCaptureTime = postIt.ERCaptureTime,
+                            SOCaptureTime = postIt.SOCaptureTime,
+
+                            Subject = trackedSubject,
+                            subjectID = trackedSubject.subjectID
+                        };
+
+                        existingLog.PostItList.Add(newPostIt);
                     }
                     else
                     {
-                        // Existing PostIt → update
-                        var trackedPostIt = existingLog.PostItList.First(p => p.postItID == postIt.postItID);
+                        var trackedPostIt = existingLog.PostItList
+                            .First(p => p.postItID == postIt.postItID);
 
-                        // Update scalar properties
-                        master.Entry(trackedPostIt).CurrentValues.SetValues(postIt);
+                        // explicit update
+                        trackedPostIt.Error = postIt.Error;
+                        trackedPostIt.Solution = postIt.Solution;
+                        trackedPostIt.Suggestion = postIt.Suggestion;
+                        trackedPostIt.Comment = postIt.Comment;
+                        trackedPostIt.ERCaptureTime = postIt.ERCaptureTime;
+                        trackedPostIt.SOCaptureTime = postIt.SOCaptureTime;
 
-                        // Update navigation property manually
                         if (postIt.Subject != null)
                         {
-                            // Reuse already-tracked Subject if possible
                             var trackedSubject = master.Subjects.Local
-                                .FirstOrDefault(s => s.subjectID == postIt.Subject.subjectID)
-                                ?? postIt.Subject;
+                                .FirstOrDefault(s => s.subjectID == postIt.Subject.subjectID) ?? postIt.Subject;
 
                             trackedPostIt.Subject = trackedSubject;
+                            trackedPostIt.subjectID = trackedSubject.subjectID;
                         }
-
                     }
                 }
 
-
-
                 await master.SaveChangesAsync();
             }
-            catch (InvalidOperationException invex)
+            catch (ArgumentNullException nullex)
             {
                 var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
-                await writer.HandleExceptionAsync(invex, "UpdateLogAsync(log)", "InvalidOperationException");
+                await writer.HandleExceptionAsync(nullex, "UpdateLogAsync(log)", "InvalidOperationException");
             }
             catch (Exception ex)
             {

--- a/Services/ENTITYHANDLER.cs
+++ b/Services/ENTITYHANDLER.cs
@@ -148,8 +148,6 @@ namespace Data_Logger_1._3.Services
                             var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                             trackedSubject.Application = existingLog.Application;
                             trackedSubject.Project = existingLog.Project;
-
-                            await writer.AddSubject(trackedSubject, scope);
                         }
 
 

--- a/Services/ENTITYHANDLER.cs
+++ b/Services/ENTITYHANDLER.cs
@@ -35,7 +35,7 @@ namespace Data_Logger_1._3.Services
         /// Updates a log in the database.
         /// </summary>
         /// <param name="log">The log needing updates.</param>
-        /// <returns>Returns a scope. (use of the scope is optional)</returns>
+        /// <returns></returns>
         public async Task UpdateLogAsync(LOG log)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
@@ -60,19 +60,35 @@ namespace Data_Logger_1._3.Services
                 master.Entry(existingLog).CurrentValues.SetValues(log);
 
                 if (log.Application != null)
-                    existingLog.Application = master.Applications.Local
-                        .FirstOrDefault(a => a.appID == log.Application.appID) ?? log.Application;
+                {
+                    if (log.Application.appID == 0)
+                    {
+                        // New App
+                        existingLog.Application = log.Application;
+                    }
+                }
 
-                if (log.Project != null)
-                    existingLog.Project = master.Projects.Local
-                        .FirstOrDefault(p => p.projectID == log.Project.projectID) ?? log.Project;
+
+                // PROJECT
+                if (log.projectID != 0 && log.projectID != existingLog.projectID)
+                {
+                    existingLog.projectID = log.projectID;
+                    existingLog.Project = null;
+                }
+                else if (log.Project != null && log.Project.projectID == 0)
+                {
+                    // If the application is existing, use the tracked app; 
+                    // if it's new, the reference is already set correctly in the command
+                    log.Project.Application = existingLog.Application!;
+                    existingLog.Project = log.Project;
+                }
 
                 if (log.Output != null)
-                    existingLog.Output = master.Outputs.Local
+                    existingLog.Output = master.Outputs
                         .FirstOrDefault(o => o.outputID == log.Output.outputID) ?? log.Output;
 
                 if (log.Type != null)
-                    existingLog.Type = master.Types.Local
+                    existingLog.Type = master.Types
                         .FirstOrDefault(t => t.typeID == log.Type.typeID) ?? log.Type;
 
                 var incomingIds = log.PostItList
@@ -92,48 +108,94 @@ namespace Data_Logger_1._3.Services
                 // ADD + UPDATE
                 foreach (var postIt in log.PostItList)
                 {
-                    if (postIt.postItID == 0)
+                    // resolve subject
+
+                    SubjectClass? trackedSubject = null;
+                    bool subjectIsNew = false;
+
+                    if (postIt.Subject != null)
                     {
-                        // resolve subject
-                        var trackedSubject = master.Subjects.Local
-                            .FirstOrDefault(s => s.subjectID == postIt.subjectID) ?? postIt.Subject;
+                        subjectIsNew = postIt.Subject.subjectID == 0;
 
-                        // create new entity
-                        var newPostIt = new PostIt
+                        if (subjectIsNew)
                         {
-                            Error = postIt.Error,
-                            Solution = postIt.Solution,
-                            Suggestion = postIt.Suggestion,
-                            Comment = postIt.Comment,
-                            ERCaptureTime = postIt.ERCaptureTime,
-                            SOCaptureTime = postIt.SOCaptureTime,
-
-                            Subject = trackedSubject,
-                            subjectID = trackedSubject.subjectID
-                        };
-
-                        existingLog.PostItList.Add(newPostIt);
+                            trackedSubject = postIt.Subject;
+                        }
+                        else
+                        {
+                            trackedSubject = await master.Subjects
+                                .FirstOrDefaultAsync(s => s.subjectID == postIt.Subject.subjectID) ?? postIt.Subject;
+                        }
                     }
                     else
                     {
-                        var trackedPostIt = existingLog.PostItList
-                            .First(p => p.postItID == postIt.postItID);
+                        // Subject Exists
+                        trackedSubject = master.Subjects
+                            .FirstOrDefault(s => s.subjectID == postIt.subjectID);
+                    }
 
-                        // explicit update
-                        trackedPostIt.Error = postIt.Error;
-                        trackedPostIt.Solution = postIt.Solution;
-                        trackedPostIt.Suggestion = postIt.Suggestion;
-                        trackedPostIt.Comment = postIt.Comment;
-                        trackedPostIt.ERCaptureTime = postIt.ERCaptureTime;
-                        trackedPostIt.SOCaptureTime = postIt.SOCaptureTime;
 
-                        if (postIt.Subject != null)
+
+
+                    if (trackedSubject != null)
+                    {
+                        // Subject is NEW
+                        if (subjectIsNew)
                         {
-                            var trackedSubject = master.Subjects.Local
-                                .FirstOrDefault(s => s.subjectID == postIt.Subject.subjectID) ?? postIt.Subject;
+                            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
+                            trackedSubject.appID = existingLog.appID;
+                            trackedSubject.projectID = existingLog.projectID;
 
-                            trackedPostIt.Subject = trackedSubject;
-                            trackedPostIt.subjectID = trackedSubject.subjectID;
+                            // trackedSubject will be tracked
+                            await writer.AddSubject(trackedSubject, scope);
+                        }
+
+
+
+                        // Resolve PostIts
+
+                        // PostIt is NEW
+                        if (postIt.postItID == 0)
+                        {
+
+                            // create new entity
+                            var newPostIt = new PostIt
+                            {
+                                accountID = existingLog.Author.accountID,
+                                logID = existingLog.ID,
+                                Error = postIt.Error,
+                                Solution = postIt.Solution,
+                                Suggestion = postIt.Suggestion,
+                                Comment = postIt.Comment,
+                                ERCaptureTime = postIt.ERCaptureTime,
+                                SOCaptureTime = postIt.SOCaptureTime,
+                            };
+
+                            if (!subjectIsNew)
+                                newPostIt.subjectID = trackedSubject.subjectID;
+                            else
+                                newPostIt.Subject = trackedSubject;
+
+                            existingLog.PostItList.Add(newPostIt);
+                        }
+                        else
+                        {
+                            var trackedPostIt = existingLog.PostItList
+                                .First(p => p.postItID == postIt.postItID);
+
+                            // explicit update
+                            trackedPostIt.Error = postIt.Error;
+                            trackedPostIt.Solution = postIt.Solution;
+                            trackedPostIt.Suggestion = postIt.Suggestion;
+                            trackedPostIt.Comment = postIt.Comment;
+                            trackedPostIt.ERCaptureTime = postIt.ERCaptureTime;
+                            trackedPostIt.SOCaptureTime = postIt.SOCaptureTime;
+
+                            if (subjectIsNew)
+                                trackedPostIt.Subject = trackedSubject;
+                            else
+                                trackedPostIt.subjectID = trackedSubject.subjectID;
+
                         }
                     }
                 }

--- a/Services/ENTITYHANDLER.cs
+++ b/Services/ENTITYHANDLER.cs
@@ -142,11 +142,13 @@ namespace Data_Logger_1._3.Services
                         // Subject is NEW
                         if (subjectIsNew)
                         {
-                            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
-                            trackedSubject.appID = existingLog.appID;
-                            trackedSubject.projectID = existingLog.projectID;
+                            if (existingLog.Application == null || existingLog.Project == null)
+                                throw new InvalidOperationException("Application and Project must be set before creating a new Subject.");
 
-                            // trackedSubject will be tracked
+                            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
+                            trackedSubject.Application = existingLog.Application;
+                            trackedSubject.Project = existingLog.Project;
+
                             await writer.AddSubject(trackedSubject, scope);
                         }
 

--- a/Services/ENTITYHANDLER.cs
+++ b/Services/ENTITYHANDLER.cs
@@ -1,18 +1,19 @@
 ﻿using Data_Logger_1._3.Models;
+using Data_Logger_1._3.Models.App_Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Data_Logger_1._3.Services
 {
-    public class ENTITYHANDLER
+    public class EntityHandler
     {
         private readonly IServiceProvider _serviceProvider;
 
 
         /// <summary>
-        /// The Entity Framework updater and deleter for ENTITYMASTER.
+        /// The Entity Framework updater and deleter for EntityMaster.
         /// </summary>
-        public ENTITYHANDLER(IServiceProvider serviceProvider)
+        public EntityHandler(IServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider;
         }
@@ -41,7 +42,7 @@ namespace Data_Logger_1._3.Services
 
             try
             {
-                var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+                var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
                 var existingLog = await master.Logs
                     .Include(l => l.Author)
@@ -141,12 +142,12 @@ namespace Data_Logger_1._3.Services
             }
             catch (ArgumentNullException nullex)
             {
-                var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                 await writer.HandleExceptionAsync(nullex, "UpdateLogAsync(log)", "InvalidOperationException");
             }
             catch (Exception ex)
             {
-                var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                 await writer.HandleExceptionAsync(ex, "UpdateLogAsync(log)");
             }
         }
@@ -159,7 +160,7 @@ namespace Data_Logger_1._3.Services
 
             try
             {
-                var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+                var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
                 master.NoteItems.Update(noteItem);
 
                 await master.SaveChangesAsync();
@@ -168,7 +169,7 @@ namespace Data_Logger_1._3.Services
             }
             catch (Exception ex)
             {
-                var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                 await writer.HandleExceptionAsync(ex, "UpdateLogAsync(log)");
             }
 
@@ -203,7 +204,7 @@ namespace Data_Logger_1._3.Services
 
             try
             {
-                var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+                var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
                 if (log == null)
                     return false;
@@ -216,7 +217,7 @@ namespace Data_Logger_1._3.Services
             }
             catch (Exception ex)
             {
-                var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                 await writer.HandleExceptionAsync(ex, "DeleteLOG(log)");
             }
 
@@ -229,7 +230,7 @@ namespace Data_Logger_1._3.Services
 
             try
             {
-                var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+                var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
                 var logDeletionCandidate = await master.Logs
                 .FirstOrDefaultAsync(log => log.ID == ID);
@@ -245,7 +246,7 @@ namespace Data_Logger_1._3.Services
             }
             catch (Exception ex)
             {
-                var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+                var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
                 await writer.HandleExceptionAsync(ex, "DeleteLOGByID(ID)");
             }
 
@@ -255,8 +256,8 @@ namespace Data_Logger_1._3.Services
         public async Task<bool> DeleteNote(int ID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {

--- a/Services/ENTITYMASTER.cs
+++ b/Services/ENTITYMASTER.cs
@@ -5,7 +5,7 @@ using SQLitePCL;
 
 namespace Data_Logger_1._3.Services
 {
-    public class ENTITYMASTER : DbContext
+    public class EntityMaster : DbContext
     {
 
         public DbSet<ApplicationClass> Applications { get; set; }
@@ -31,7 +31,7 @@ namespace Data_Logger_1._3.Services
         public DbSet<FeedbackMessage> AllFeedback { get; set; }
 
 
-        public ENTITYMASTER(DbContextOptions<ENTITYMASTER> options)
+        public EntityMaster(DbContextOptions<EntityMaster> options)
         : base(options)
         {
             Batteries_V2.Init();

--- a/Services/ENTITYREADER.cs
+++ b/Services/ENTITYREADER.cs
@@ -9,15 +9,15 @@ using static Data_Logger_1._3.Models.LOG;
 
 namespace Data_Logger_1._3.Services
 {
-    public class ENTITYREADER
+    public class EntityReader
     {
         private readonly IServiceProvider _serviceProvider;
 
 
         /// <summary>
-        /// The Entity Framework data reader for ENTITYMASTER.
+        /// The Entity Framework data reader for EntityMaster.
         /// </summary>
-        public ENTITYREADER(IServiceProvider serviceProvider)
+        public EntityReader(IServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider;
         }
@@ -25,7 +25,7 @@ namespace Data_Logger_1._3.Services
         public async Task<AsyncServiceScope> SaveChangesAsync()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             await master.SaveChangesAsync();
 
@@ -35,7 +35,7 @@ namespace Data_Logger_1._3.Services
         public async Task<AsyncServiceScope> SaveChangesAsync(LOG log)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             if (!master.Logs.Local.Contains(log))
             {
@@ -49,7 +49,7 @@ namespace Data_Logger_1._3.Services
 
         public async Task SaveChangesAsync(AsyncServiceScope scope)
         {
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             await master.SaveChangesAsync();
         }
@@ -62,7 +62,7 @@ namespace Data_Logger_1._3.Services
         public async Task<string> RetrieveProfilePic(string emailAddress)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             return await master.Accounts
                 .Where(a => a.Email == emailAddress)
@@ -81,7 +81,7 @@ namespace Data_Logger_1._3.Services
         public async Task<LOG?> RetrieveLog(int id)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -94,7 +94,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<LOG>> RetrieveLogs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -111,7 +111,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<CodingLOG>> RetrieveCodingLogs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -131,7 +131,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<CodingLOG>> RetrieveQtCodingLogs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -144,7 +144,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<AndroidCodingLOG>> RetrieveAndroidCodingLogs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -157,7 +157,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<GraphicsLOG>> RetrieveGraphicsLogs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -170,7 +170,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<FilmLOG>> RetrieveFilmLogs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -183,7 +183,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<FlexiNotesLOG>> RetrieveFlexiNotesLogs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -197,7 +197,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<NoteItem>> RetrieveGenericNotes(int id)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             return await master.NoteItems
                 .Where(n => n.accountID == id)
@@ -207,7 +207,7 @@ namespace Data_Logger_1._3.Services
         public async Task<List<CheckList>> RetrieveCheckList()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             var accountID = await GetOnlineAccountIDAsync();
 
@@ -223,8 +223,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> GetOnlineAccountIDAsync()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -245,9 +245,9 @@ namespace Data_Logger_1._3.Services
         /// Find the account ID of the user who's online.
         /// </summary>
         /// <returns>Returns a single account ID</returns>
-        public async Task<int?> GetOnlineAccountIDAsync(AsyncServiceScope scope, ENTITYMASTER master)
+        public async Task<int?> GetOnlineAccountIDAsync(AsyncServiceScope scope, EntityMaster master)
         {
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -268,8 +268,8 @@ namespace Data_Logger_1._3.Services
         public async Task<ACCOUNT?> FindAccountByID(int id)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -287,9 +287,9 @@ namespace Data_Logger_1._3.Services
             }
         }
 
-        public async Task<ACCOUNT?> FindAccountByID(AsyncServiceScope scope, ENTITYMASTER master, int id)
+        public async Task<ACCOUNT?> FindAccountByID(AsyncServiceScope scope, EntityMaster master, int id)
         {
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -310,8 +310,8 @@ namespace Data_Logger_1._3.Services
         public async Task<ACCOUNT?> FindAccountByEmail(string emailAddress, string password)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -339,8 +339,8 @@ namespace Data_Logger_1._3.Services
         public async Task<ApplicationClass?> FindApplication(string name)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -360,8 +360,8 @@ namespace Data_Logger_1._3.Services
         public async Task<ApplicationClass?> FindApplication(int? ID, string name)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -382,9 +382,9 @@ namespace Data_Logger_1._3.Services
             return null;
         }
 
-        public async Task<ApplicationClass?> FindApplication(AsyncServiceScope scope, ENTITYMASTER master, int? ID, string name)
+        public async Task<ApplicationClass?> FindApplication(AsyncServiceScope scope, EntityMaster master, int? ID, string name)
         {
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -409,8 +409,8 @@ namespace Data_Logger_1._3.Services
         public async Task<ApplicationClass?> FindApplicationByID(int appID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -430,8 +430,8 @@ namespace Data_Logger_1._3.Services
         public async Task<ProjectClass?> FindProject(int? userID, string projectName, int appID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -454,9 +454,9 @@ namespace Data_Logger_1._3.Services
             return null;
         }
 
-        public async Task<ProjectClass?> FindProject(AsyncServiceScope scope, ENTITYMASTER master, int? userID, string projectName, int appID)
+        public async Task<ProjectClass?> FindProject(AsyncServiceScope scope, EntityMaster master, int? userID, string projectName, int appID)
         {
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -483,8 +483,8 @@ namespace Data_Logger_1._3.Services
         public async Task<ProjectClass?> FindProjectByID(int projectID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -504,8 +504,8 @@ namespace Data_Logger_1._3.Services
         public async Task<OutputClass?> FindOutput(string name)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -521,9 +521,9 @@ namespace Data_Logger_1._3.Services
             return null;
         }
 
-        public async Task<OutputClass?> FindOutput(AsyncServiceScope scope, ENTITYMASTER master, string name)
+        public async Task<OutputClass?> FindOutput(AsyncServiceScope scope, EntityMaster master, string name)
         {
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -542,8 +542,8 @@ namespace Data_Logger_1._3.Services
         public async Task<OutputClass?> FindOutputByID(int outputID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -563,8 +563,8 @@ namespace Data_Logger_1._3.Services
         public async Task<TypeClass?> FindType(string name)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -580,9 +580,9 @@ namespace Data_Logger_1._3.Services
             return null;
         }
 
-        public async Task<TypeClass?> FindType(AsyncServiceScope scope, ENTITYMASTER master, string name)
+        public async Task<TypeClass?> FindType(AsyncServiceScope scope, EntityMaster master, string name)
         {
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -601,8 +601,8 @@ namespace Data_Logger_1._3.Services
         public async Task<TypeClass?> FindTypeByID(int typeID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -627,7 +627,7 @@ namespace Data_Logger_1._3.Services
         {
             try
             {
-                string hashedPassword = ENTITYWRITER.SaltedSHA256Hash(password, account.accountID.ToString());
+                string hashedPassword = EntityWriter.SaltedSHA256Hash(password, account.accountID.ToString());
                 return hashedPassword == account.Password;
             }
             catch (Exception ex)
@@ -650,8 +650,8 @@ namespace Data_Logger_1._3.Services
         public async Task<bool> EmailExists(string email)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -688,8 +688,8 @@ namespace Data_Logger_1._3.Services
         /// <exception cref="EmailConflictException"></exception>
         public async Task<bool> EmailExists(AsyncServiceScope scope, string email)
         {
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -725,7 +725,7 @@ namespace Data_Logger_1._3.Services
         public async Task<bool> PostItsExists(int logID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             return await master.PostIts.AnyAsync(p =>
                     p.logID == logID);
@@ -741,8 +741,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> FindAccountIDAsync(ACCOUNT account)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -774,8 +774,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> FindAppID(ApplicationClass app)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -809,8 +809,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> FindProjectID(ProjectClass project)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             if (string.IsNullOrEmpty(project.Name) || project.Name == "Unknown")
                 return 1;
@@ -856,8 +856,8 @@ namespace Data_Logger_1._3.Services
         public async Task<SubjectClass?> FindSubject(string name, LOG.CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -877,9 +877,9 @@ namespace Data_Logger_1._3.Services
             return null;
         }
 
-        public async Task<SubjectClass?> FindSubject(AsyncServiceScope scope, ENTITYMASTER master, string name, LOG.CATEGORY category)
+        public async Task<SubjectClass?> FindSubject(AsyncServiceScope scope, EntityMaster master, string name, LOG.CATEGORY category)
         {
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -907,8 +907,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> FindSubjectID(SubjectClass subject)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             int subjectKey = 1;
 
@@ -944,8 +944,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> LogCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -969,8 +969,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int?> LogCount(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1001,8 +1001,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> QtLogCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1033,8 +1033,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> ASLogCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1066,8 +1066,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> CodingLogCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1099,8 +1099,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> GraphicsLogCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1130,8 +1130,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> FilmLogCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1160,8 +1160,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> NoteItemCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1191,8 +1191,8 @@ namespace Data_Logger_1._3.Services
         public async Task<int> FlexiNotesLogCount()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1225,8 +1225,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<ApplicationClass>> ListApplications()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1258,8 +1258,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<ApplicationClass>> ListApplications(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1292,8 +1292,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<ProjectClass>> ListProjects()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1326,8 +1326,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<ProjectClass>> ListProjects(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1363,8 +1363,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<ProjectClass>> ListProjects(ApplicationClass app)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1399,8 +1399,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<SubjectClass>> ListSubjects(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1434,8 +1434,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<SubjectClass>> ListSubjects(ProjectClass project)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1471,8 +1471,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<OutputClass>> ListQtOutputs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1501,8 +1501,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<OutputClass>> ListASOutputs()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1530,8 +1530,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<OutputClass>> ListOutputs(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1565,8 +1565,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<TypeClass>> ListQtTypes()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1593,8 +1593,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<TypeClass>> ListASTypes()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1622,8 +1622,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<TypeClass>> ListTypes(CATEGORY category)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1668,8 +1668,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<CodingLOG>?> SearchCodingLogs(string searchBarText)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1732,8 +1732,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<CodingLOG>?> SearchCodingLogs(string searchBarText, int appID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {
@@ -1802,8 +1802,8 @@ namespace Data_Logger_1._3.Services
         public async Task<List<CodingLOG>?> SearchCodingLogs(string searchBarText, int projectID, int appID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var writer = scope.ServiceProvider.GetRequiredService<ENTITYWRITER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
             try
             {

--- a/Services/ENTITYWRITER.cs
+++ b/Services/ENTITYWRITER.cs
@@ -188,10 +188,11 @@ namespace Data_Logger_1._3.Services
             await using var scope = _serviceProvider.CreateAsyncScope();
             var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
 
-            await using var transaction = await master.Database.BeginTransactionAsync();
 
             try
             {
+                await using var transaction = await master.Database.BeginTransactionAsync();
+                
                 await PrepareLogDetails(log, scope, master);
                 await PreparePostItDetails(log, scope, master);
 
@@ -214,14 +215,6 @@ namespace Data_Logger_1._3.Services
             catch (Exception ex)
             {
                 await HandleExceptionAsync(ex, "CreateLOG(log)");
-            }
-            finally
-            {
-                var dbConnection = transaction.GetDbTransaction().Connection;
-                if (transaction != null && master.Database.CurrentTransaction != null)
-                {
-                    await transaction.RollbackAsync();
-                }
             }
 
             return false;

--- a/Services/ENTITYWRITER.cs
+++ b/Services/ENTITYWRITER.cs
@@ -1,4 +1,5 @@
 ﻿using Data_Logger_1._3.Models;
+using Data_Logger_1._3.Models.App_Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,18 +11,18 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using static Data_Logger_1._3.Models.FeedbackMessage;
 using static Data_Logger_1._3.Models.NotesLOG;
-using static Data_Logger_1._3.Services.ENTITYREADER;
+using static Data_Logger_1._3.Services.EntityReader;
 
 namespace Data_Logger_1._3.Services
 {
-    public class ENTITYWRITER
+    public class EntityWriter
     {
         private readonly IServiceProvider _serviceProvider;
 
         /// <summary>
         /// Official Entity Framework data writer.
         /// </summary>
-        public ENTITYWRITER(IServiceProvider serviceProvider)
+        public EntityWriter(IServiceProvider serviceProvider)
         {
             _serviceProvider = serviceProvider;
         }
@@ -48,8 +49,8 @@ namespace Data_Logger_1._3.Services
         public async Task<bool> SetCurrentUser(ACCOUNT account)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
 
             try
             {
@@ -79,7 +80,7 @@ namespace Data_Logger_1._3.Services
         public async Task<bool> UnsetCurrentUser()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             try
             {
@@ -114,8 +115,8 @@ namespace Data_Logger_1._3.Services
         public async Task<bool> AddAccount(ACCOUNT account)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
-            var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
+            var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
 
             bool accountCreated = false;
 
@@ -186,7 +187,7 @@ namespace Data_Logger_1._3.Services
         public async Task<bool> CreateLOG(LOG log)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             await using var transaction = await master.Database.BeginTransactionAsync();
 
@@ -228,9 +229,9 @@ namespace Data_Logger_1._3.Services
         }
 
 
-        private async Task PrepareLogDetails(LOG log, AsyncServiceScope scope, ENTITYMASTER master)
+        private async Task PrepareLogDetails(LOG log, AsyncServiceScope scope, EntityMaster master)
         {
-            var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+            var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
 
             var onlineUser = await reader.FindAccountByID(scope, master, (int)await reader.GetOnlineAccountIDAsync(scope, master));
             if (onlineUser == null)
@@ -284,9 +285,9 @@ namespace Data_Logger_1._3.Services
             return regex.IsMatch(input) ? input : string.Empty;
         }
 
-        private async Task PreparePostItDetails(LOG log, AsyncServiceScope scope, ENTITYMASTER master)
+        private async Task PreparePostItDetails(LOG log, AsyncServiceScope scope, EntityMaster master)
         {
-            var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+            var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
 
             var onlineUser = await reader.FindAccountByID(scope, master, (int)await reader.GetOnlineAccountIDAsync(scope, master));
 
@@ -314,7 +315,7 @@ namespace Data_Logger_1._3.Services
             }
         }
 
-        private async Task InsertSubLogDetails(LOG log, AsyncServiceScope scope, ENTITYMASTER master)
+        private async Task InsertSubLogDetails(LOG log, AsyncServiceScope scope, EntityMaster master)
         {
 
             switch (log.Category)
@@ -420,7 +421,7 @@ namespace Data_Logger_1._3.Services
         public async Task<int> CreateFeedback(int accountID, string description, bool canContact, bool isAutoFeed = true, FeedbackType category = FeedbackType.Bug)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             try
             {

--- a/Services/InitialService.cs
+++ b/Services/InitialService.cs
@@ -195,7 +195,7 @@ namespace Data_Logger_1._3.Services
         private async Task LoadNotes(int id)
         {
             using var scope = _serviceProvider.CreateScope();
-            var reader = scope.ServiceProvider.GetRequiredService<ENTITYREADER>();
+            var reader = scope.ServiceProvider.GetRequiredService<EntityReader>();
 
             foreach (var note in await reader.RetrieveGenericNotes(id))
             {

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -263,7 +263,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToMainWindow()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -328,7 +328,7 @@ namespace Data_Logger_1._3.Services
             where TViewModel : ViewModelBase
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -412,7 +412,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToPage(Page page, ViewModelBase viewModel, UserControl subPage = null)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
 
@@ -454,7 +454,7 @@ namespace Data_Logger_1._3.Services
             where TViewModel : ViewModelBase
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
 
@@ -482,7 +482,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToPage(Page page)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -629,7 +629,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToLoggerCreator()
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -719,7 +719,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToLoggerEditor(ViewModelBase viewModelBase)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -806,7 +806,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToViewer(ViewModelBase viewModelBase)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -874,7 +874,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToViewer(LOG log)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -939,7 +939,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToLogViewer(LOG log)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
             var dataService = _serviceProvider.GetRequiredService<IDataService>();
 
             try
@@ -1002,7 +1002,7 @@ namespace Data_Logger_1._3.Services
         public async Task NavigateToUpdater(LOG log, ReportDeskViewModel reportDeskViewModel)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
-            var master = scope.ServiceProvider.GetRequiredService<ENTITYMASTER>();
+            var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
 
             try
             {


### PR DESCRIPTION
Fixes an issue where creating a log with an empty project name would generate duplicate "Unnamed Project" entries instead of reusing the existing default project. This change ensures empty project names are handled correctly and the default project (projectID = 1) is reused, preventing database duplication and improving consistency. Closes #13 