### PR TITLE
fix: post it update logic

### DIFF
--- a/Commands/ReporterCommands/UpdateCommands/UpdateCommand.cs
+++ b/Commands/ReporterCommands/UpdateCommands/UpdateCommand.cs
@@ -93,7 +93,7 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
 
                 // PROJECT
 
-                if (!appIsNew)
+                if (!appIsNew && _log.Project != null)
                 {
                     bool projectBelongsToNewApp = _log.Project.appID == _log.appID;
 
@@ -125,7 +125,14 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                 }
                 else
                 {
-                    _log.Project = new ProjectClass(account, _editor.ProjectName, _log.Application!);
+                    if (string.IsNullOrEmpty(_editor.ProjectName))
+                    {
+                        // Set to "Unnamed Project" default
+                        _log.projectID = 1;
+                        _log.Project = null;
+                    }
+                    else
+                        _log.Project = new ProjectClass(account, _editor.ProjectName, _log.Application!);
                 }
 
 

--- a/Commands/ReporterCommands/UpdateCommands/UpdateCommand.cs
+++ b/Commands/ReporterCommands/UpdateCommands/UpdateCommand.cs
@@ -58,6 +58,7 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
 
 
                 bool appIsNew = false;
+                bool projectIsNew = false;
 
                 // APPLICATION
 
@@ -72,12 +73,12 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                     // App may be the same or changed. Changed app may be new or existing
                     var app = await _dataService.FindApplication(userID, _editor.ApplicationName);
 
-                    if(app == null)
+                    if (app == null)
                     {
                         app = new ApplicationClass(_editor.ApplicationName);
-                        app.accountID = _log.accountID;                    
+                        app.accountID = _log.accountID;
                     }
-                        
+
                     appIsNew = app.appID == 0;
 
                     if (appIsNew)
@@ -114,6 +115,8 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                             project.appID = _log.appID;
                         }
 
+                        projectIsNew = project.projectID == 0;
+
                         if (project.projectID == 0)
                             _log.Project = project;
                         else
@@ -132,7 +135,10 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                         _log.Project = null;
                     }
                     else
+                    {
                         _log.Project = new ProjectClass(account, _editor.ProjectName, _log.Application!);
+                        projectIsNew = true;
+                    }
                 }
 
 
@@ -152,9 +158,9 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                 foreach (var editorPostIt in _editor.PostIts)
                 {
                     var subjectIsNew = false;
-                    var subject = await _dataService.FindSubject(editorPostIt.Subject, _log.Category);
+                    var subject = await _dataService.FindSubject(editorPostIt.Subject, _log.Category, _log.appID, _log.projectID);
 
-                    if (subject == null)
+                    if (subject == null || appIsNew || projectIsNew)
                     {
                         subjectIsNew = true;
                         subject = new(
@@ -218,6 +224,7 @@ namespace Data_Logger_1._3.Commands.ReporterCommands.UpdateCommands
                         {
                             // PostIt Exists, Subject Exists
                             existingPostIt.subjectID = subject.subjectID;
+                            existingPostIt.Subject = null;
                         }
 
                         existingPostIt.Error = editorPostIt.Error;

--- a/DLSTests/ENTITYMASTERTests.cs
+++ b/DLSTests/ENTITYMASTERTests.cs
@@ -3,7 +3,7 @@ using Data_Logger_1._3.Services;
 using Microsoft.EntityFrameworkCore;
 using System.Runtime.CompilerServices;
 
-namespace DataLoggerTest
+namespace DLSTests
 {
     public class ENTITYMASTERTests
     {

--- a/DLSTests/HANDLERUpdateTests.cs
+++ b/DLSTests/HANDLERUpdateTests.cs
@@ -1,16 +1,18 @@
-﻿using Data_Logger_1._3.Models;
+﻿using Data_Logger_1._3;
+using Data_Logger_1._3.Models;
 using Data_Logger_1._3.Models.App_Models;
 using Data_Logger_1._3.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using System.Security.Principal;
 
-namespace DataLoggerTest
+namespace DLSTests
 {
     public class HANDLERUpdateTests : ENTITYMASTERTests
     {
-        private async Task<CodingLOG> SeedTestDataAsync(EntityMaster master)
+        private static async Task<CodingLOG> SeedTestDataAsync(EntityMaster master)
         {
-            // 1. Author
+            // Author
             var author = new ACCOUNT
             {
                 accountID = 1,
@@ -21,7 +23,7 @@ namespace DataLoggerTest
                 ProfilePic = "/Assets/login/user.png"
             };
 
-            // 2. Nav Data
+            // Nav Data
             var app1 = new ApplicationClass(author, "Visual Studio");
             var project1 = new ProjectClass(author, "Project Alpha", app1);
             var output1 = new OutputClass(1, "EXE");
@@ -33,7 +35,7 @@ namespace DataLoggerTest
             master.Types.Add(type1);
             await master.SaveChangesAsync();
 
-            // 3. Subject
+            // Subject
             var subject = new SubjectClass
             {
                 Category = LOG.CATEGORY.CODING,
@@ -45,11 +47,11 @@ namespace DataLoggerTest
             master.Subjects.Add(subject);
             await master.SaveChangesAsync();
 
-            // 4. Post-Its
+            // Post-Its
             var postItToUpdate = new PostIt { Subject = subject, subjectID = subject.subjectID, accountID = author.accountID, Error = "Old Error" };
             var postItToDelete = new PostIt { Subject = subject, subjectID = subject.subjectID, accountID = author.accountID, Error = "Delete Error" };
 
-            // 5. The Log
+            // The Log
             var originalLog = new CodingLOG
             {
                 ID = 1,
@@ -75,176 +77,55 @@ namespace DataLoggerTest
             return originalLog;
         }
 
-
-
-
-
-
-
-
-
-        #region EXISTING TO EXISTING APP
-
-
-        /// <summary>
-        /// Test the updating of application in the log to an existing application.
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public async Task UpdateLogAsync_Should_Change_App_To_Existing_App()
+        private static async Task<CodingLOG> SeedTestDataAsync(EntityMaster master, ACCOUNT account,
+            List<ApplicationClass>? apps = null, List<ProjectClass>? projects = null,
+            List<SubjectClass>? subjects = null, List<PostIt>? postIts = null)
         {
-            var services = new ServiceCollection();
+            apps ??= new();
+            projects ??= new();
+            subjects ??= new();
+            postIts ??= new();
 
-            // In memory database
-            services.AddDbContext<EntityMaster>(options => options.UseInMemoryDatabase(GetTestDbName()));
-
-            // Writer
-            services.AddScoped((services) => new EntityWriter(services));
-
-            // Handler
-            services.AddScoped((services) => new EntityHandler(services));
-
-            var serviceProvider = services.BuildServiceProvider();
-            using var master = serviceProvider.GetRequiredService<EntityMaster>();
-
-            // Seed parent/nav data
-            var author = new ACCOUNT
-            {
-                accountID = 1,
-                ProfilePic = "/Assets/login/user.png",
-                FirstName = "Ninja",
-                LastName = "Dev",
-                Email = "ninja@test.com",
-                Password = "test123",
-                IsEmployee = false,
-                CompanyName = "",
-                CompanyAddress = "",
-                CompanyLogo = "",
-                IsOnline = true
-            };
-
-            var app1 = new ApplicationClass(author, "Visual Studio");
-            var app2 = new ApplicationClass(author, "VS Code");
-
-            master.Applications.AddRange(app1, app2);
+            master.Applications.AddRange(apps);
+            master.Projects.AddRange(projects);
+            master.Subjects.AddRange(subjects);
             await master.SaveChangesAsync();
 
-            var project1 = new ProjectClass(author, "Project Alpha", app1);
-            var project2 = new ProjectClass(author, "Project Beta", app2);
-
-            master.Projects.AddRange(project1, project2);
-
-            var output1 = new OutputClass(1, "EXE");
-            var output2 = new OutputClass(2, "DLL");
-
-            master.Outputs.AddRange(output1, output2);
-
-            var type1 = new TypeClass(1, "Bug Report");
-            var type2 = new TypeClass(2, "Feature Update");
-
-            master.Types.AddRange(type1, type2);
-
-            await master.SaveChangesAsync();
-
-            // Seed subjects
-            var existingSubject = new SubjectClass
-            {
-                Category = LOG.CATEGORY.CODING,
-                accountID = author.accountID,
-                Subject = "Existing Subject",
-                projectID = project1.projectID,
-                appID = app1.appID
-            };
-
-            master.Subjects.Add(existingSubject);
-            await master.SaveChangesAsync();
-
-            // Seed original log with two PostIts
-            var postItToUpdate = new PostIt
-            {
-                Subject = existingSubject,
-                subjectID = existingSubject.subjectID,
-                accountID = author.accountID,
-                Error = "Old Error",
-                Solution = "Old Solution",
-                Suggestion = "Old Suggestion",
-                Comment = "Old Comment",
-                ERCaptureTime = new DateTime(2026, 1, 1),
-                SOCaptureTime = new DateTime(2026, 1, 2)
-            };
-
-            var postItToDelete = new PostIt
-            {
-                Subject = existingSubject,
-                subjectID = existingSubject.subjectID,
-                accountID = author.accountID,
-                Error = "Delete Error",
-                Solution = "Delete Solution",
-                Suggestion = "Delete Suggestion",
-                Comment = "Delete Comment",
-                ERCaptureTime = new DateTime(2026, 1, 3),
-                SOCaptureTime = new DateTime(2026, 1, 4)
-            };
-
-            var originalLog = new CodingLOG
+            var log = new CodingLOG
             {
                 ID = 1,
-                Author = author,
-                accountID = author.accountID,
-                Application = app1,
-                appID = app1.appID,
-                Project = project1,
-                projectID = project1.projectID,
-                Output = output1,
-                outputID = output1.outputID,
-                Type = type1,
-                typeID = type1.typeID,
-                Start = new DateTime(2026, 1, 1, 8, 0, 0),
-                End = new DateTime(2026, 1, 1, 10, 0, 0),
-                Content = "Old content",
-                Bugs = 5,
-                Success = false,
-                PostItList = new List<PostIt> { postItToUpdate, postItToDelete }
+                Author = account,
+                accountID = account.accountID,
+                Application = apps.FirstOrDefault(),
+                appID = apps.FirstOrDefault()?.appID ?? 0,
+                Project = projects.FirstOrDefault(),
+                projectID = projects.FirstOrDefault()?.projectID ?? 0,
+                PostItList = postIts
             };
 
-            master.Logs.Add(originalLog);
+            master.Logs.Add(log);
+
             await master.SaveChangesAsync();
-
-            var updatePostItId = postItToUpdate.postItID;
-            var deletePostItId = postItToDelete.postItID;
-
             master.ChangeTracker.Clear();
 
-            // ----------------------------------------
-            // LOAD LOG (simulate it being fetched somewhere else)
-            // ----------------------------------------
-            var incomingLog = (CodingLOG)await master.Logs
-                .Include(l => l.Author)
-                .Include(l => l.Application)
-                .Include(l => l.Project)
-                .Include(l => l.Output)
-                .Include(l => l.Type)
-                .Include(l => l.PostItList)
-                    .ThenInclude(p => p.Subject)
-                .FirstAsync(l => l.ID == originalLog.ID);
+            return log;
+        }
 
-            // ----------------------------------------
-            // DETACH
-            // ----------------------------------------
-            master.ChangeTracker.Clear();
-
-            // ----------------------------------------
-            // APPLY EDITOR CHANGES (now working on detached object)
-            // ----------------------------------------
-
-            // Parent updates
-            // APPLICATION
-
+        private static async Task TesterUpdateCommandAsync(CodingLOG incomingLog, EntityMaster master, string editorApplicationText,
+            string editorProjectText, int userID)
+        {
             bool appIsNew = false;
-            var editorApplicationText = app2.Name;
             var account = incomingLog.Author;
 
-            if (incomingLog.Application.Name != editorApplicationText)
+            // APPLICATION
+
+            if (string.IsNullOrEmpty(editorApplicationText))
+            {
+                // Set to "Unknown" default
+                incomingLog.appID = 3;
+                incomingLog.Application = null;
+            }
+            else if (incomingLog.Application.Name != editorApplicationText)
             {
                 // App may be the same or changed. Changed app may be new or existing
                 var app = await master.Applications.FirstOrDefaultAsync(a =>
@@ -253,7 +134,7 @@ namespace DataLoggerTest
                 if (app == null)
                 {
                     app = new ApplicationClass(editorApplicationText);
-                    app.accountID = account.accountID;
+                    app.accountID = incomingLog.accountID;
                 }
 
                 appIsNew = app.appID == 0;
@@ -267,30 +148,153 @@ namespace DataLoggerTest
                 }
             }
 
+            // PROJECT
 
+            if (!appIsNew && incomingLog.Project != null)
+            {
+                bool projectBelongsToNewApp = incomingLog.Project.appID == incomingLog.appID;
 
-            // Retrieve Dependency
-            var handler = serviceProvider.GetRequiredService<EntityHandler>();
+                if (string.IsNullOrEmpty(editorProjectText))
+                {
+                    // Set to "Unnamed Project" default
+                    incomingLog.projectID = 1;
+                    incomingLog.Project = null;
+                }
+                else if (incomingLog.Project.Name != editorProjectText || !projectBelongsToNewApp)
+                {
+                    var project = await master.Projects.FirstOrDefaultAsync(p =>
+                        p.Name == editorProjectText &&
+                        p.appID == incomingLog.appID);
 
-            // Update Log
-            await handler.UpdateLogAsync(incomingLog);
+                    if (project == null)
+                    {
+                        project = new ProjectClass(editorProjectText);
+                        project.accountID = account.accountID;
+                        project.appID = incomingLog.appID;
+                    }
 
-            // Assert with no Tracking
-            master.ChangeTracker.Clear();
-
-            var result = (CodingLOG)await master.Logs
-                .Include(l => l.Author)
-                .Include(l => l.Application)
-                .Include(l => l.Project)
-                .Include(l => l.Output)
-                .Include(l => l.Type)
-                .Include(l => l.PostItList)
-                    .ThenInclude(p => p.Subject)
-                .FirstAsync(l => l.ID == originalLog.ID);
-
-            // Parent scalar/nav assertions
-            Assert.Equal(app2.appID, result.appID);
+                    if (project.projectID == 0)
+                        incomingLog.Project = project;
+                    else
+                    {
+                        incomingLog.projectID = project.projectID;
+                        incomingLog.Project = null;
+                    }
+                }
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(editorProjectText))
+                {
+                    // Set to "Unnamed Project" default
+                    incomingLog.projectID = 1;
+                    incomingLog.Project = null;
+                }
+                else
+                    incomingLog.Project = new ProjectClass(account, editorProjectText, incomingLog.Application!);
+            }
         }
+
+        private static async Task TesterPostItUpdateCommandAsync(CodingLOG incomingLog,
+            EntityMaster master, ApplicationClass app, ProjectClass project,
+            List<PostItEditorInput> inputs)
+        {
+            foreach (var input in inputs)
+            {
+                var subject = await master.Subjects.FirstOrDefaultAsync(s =>
+                    s.Subject == input.SubjectText &&
+                    s.Category == incomingLog.Category);
+
+                bool subjectIsNew = subject == null;
+
+                if (subjectIsNew)
+                {
+                    subject = new SubjectClass
+                    {
+                        Subject = input.SubjectText,
+                        accountID = incomingLog.accountID,
+                        Category = incomingLog.Category,
+                        appID = app.appID,
+                        projectID = project.projectID
+                    };
+
+                    await master.Subjects.AddAsync(subject);
+                }
+
+                if (input.ID == 0)
+                {
+                    var newPostIt = new PostIt
+                    {
+                        Subject = subjectIsNew ? subject : null,
+                        subjectID = subjectIsNew ? 0 : subject.subjectID,
+                        Error = input.Error,
+                        ERCaptureTime = input.DateFound,
+                        Solution = input.Solution,
+                        SOCaptureTime = input.DateSolved,
+                        Suggestion = input.Suggestion,
+                        Comment = input.Comment,
+                        logID = incomingLog.ID,
+                        accountID = incomingLog.accountID
+                    };
+
+                    incomingLog.PostItList.Add(newPostIt);
+                }
+                else
+                {
+                    var existing = incomingLog.PostItList.First(p => p.postItID == input.ID);
+
+                    if (subjectIsNew)
+                    {
+                        existing.Subject = subject;
+                    }
+                    else
+                    {
+                        existing.subjectID = subject.subjectID;
+                    }
+
+                    existing.Error = input.Error;
+                    existing.ERCaptureTime = input.DateFound;
+                    existing.Solution = input.Solution;
+                    existing.SOCaptureTime = input.DateSolved;
+                    existing.Suggestion = input.Suggestion;
+                    existing.Comment = input.Comment;
+                }
+            }
+
+            var inputIds = inputs.Select(i => i.ID).ToList();
+
+            var toRemove = incomingLog.PostItList
+                .Where(p => !inputIds.Contains(p.postItID))
+                .ToList();
+
+            foreach (var removed in toRemove)
+            {
+                incomingLog.PostItList.Remove(removed);
+            }
+        }
+
+
+        // DTOs
+
+        public sealed class PostItEditorInput
+        {
+            public int ID { get; init; }
+            public string SubjectText { get; init; } = string.Empty;
+            public string Error { get; init; } = string.Empty;
+            public DateTime DateFound { get; init; }
+            public string Solution { get; init; } = string.Empty;
+            public DateTime DateSolved { get; init; }
+            public string Suggestion { get; init; } = string.Empty;
+            public string Comment { get; init; } = string.Empty;
+        }
+
+
+
+
+
+
+        #region EXISTING TO EXISTING APP
+
 
 
 
@@ -302,7 +306,7 @@ namespace DataLoggerTest
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task UpdateLogAsync_Should_Change_App_to_NEW_Existing_App_And_NEW_Existing_Project()
+        public async Task UpdateLogAsync_SwitchToExistingAppAndProject()
         {
             var services = new ServiceCollection();
 
@@ -376,76 +380,8 @@ namespace DataLoggerTest
                 // APPLY EDITOR CHANGES (now working on detached object)
                 // ----------------------------------------
 
-                // APPLICATION
-
-                bool appIsNew = false;
-                var account = incomingLog.Author;
-
-                if (incomingLog.Application.Name != editorApplicationText)
-                {
-                    // App may be the same or changed. Changed app may be new or existing
-                    var app = await master.Applications.FirstOrDefaultAsync(a =>
-                        a.Name == editorApplicationText);
-
-                    if (app == null)
-                    {
-                        app = new ApplicationClass(editorApplicationText);
-                        app.accountID = account.accountID;
-                    }
-
-                    appIsNew = app.appID == 0;
-
-                    if (appIsNew)
-                        Assert.Fail("Application should be existing.");
-                    else
-                    {
-                        incomingLog.appID = app.appID;
-                        incomingLog.Application = null;
-                    }
-                }
-
-                // PROJECT
-
-                if (!appIsNew)
-                {
-                    bool projectBelongsToNewApp = incomingLog.Project.appID == incomingLog.appID;
-
-                    if (string.IsNullOrEmpty(editorProjectText))
-                    {
-                        // Set to "Unnamed Project" default
-                        incomingLog.projectID = 1;
-                        incomingLog.Project = null;
-                    }
-                    else if (incomingLog.Project!.Name != editorProjectText || !projectBelongsToNewApp)
-                    {
-                        // Find the project by Name AND the NEW App ID
-                        var project = await master.Projects.FirstOrDefaultAsync(p =>
-                            p.Name == editorProjectText && p.appID == incomingLog.appID);
-
-                        if (project == null)
-                        {
-                            project = new ProjectClass(editorProjectText);
-                            project.accountID = account.accountID;
-                            project.appID = incomingLog.appID;
-                        }
-
-                        if (project.projectID == 0)
-                        {
-                            incomingLog.Project = project;
-                        }
-                        else
-                        {
-                            incomingLog.projectID = project.projectID;
-                            incomingLog.Project = null;
-                        }
-                    }
-
-                }
-                else
-                {
-                    Assert.Fail("Application should be existing.");
-                }
-
+                await TesterUpdateCommandAsync(incomingLog, master, editorApplicationText,
+                    editorProjectText, incomingLog.accountID);
 
 
                 // Retrieve Dependency
@@ -502,6 +438,142 @@ namespace DataLoggerTest
 
 
 
+
+        /// <summary>
+        /// #1 + #A2
+        /// Test the updating of application in the log to an existing application and changing
+        /// project to a NEW project.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task UpdateLogAsync_SwitchToExistingAppAndNewProject()
+        {
+            var services = new ServiceCollection();
+
+            // In memory database
+            services.AddDbContext<EntityMaster>(options => options.UseInMemoryDatabase(GetTestDbName()));
+
+            // Writer
+            services.AddScoped((services) => new EntityWriter(services));
+
+            // Handler
+            services.AddScoped((services) => new EntityHandler(services));
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            CodingLOG originalLog;
+            string editorApplicationText = string.Empty;
+            string editorProjectText = string.Empty;
+            int initialAppCount = 0;
+            int initialProjectCount = 0;
+
+            ApplicationClass app1, app2;
+            ProjectClass project1, project2;
+
+            using (var seedScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = seedScope.ServiceProvider.GetRequiredService<EntityMaster>();
+                originalLog = await SeedTestDataAsync(master);
+                Assert.NotEqual(0, originalLog.ID);
+                app1 = originalLog.Application;
+                app2 = new ApplicationClass(originalLog.Author, "VS Code");
+                project1 = originalLog.Project;
+                project2 = new ProjectClass(originalLog.Author, "Project Beta", app2);
+                editorApplicationText = app2.Name;
+                editorProjectText = project2.Name;
+                await master.Applications.AddAsync(app2);
+                await master.SaveChangesAsync();
+
+                initialAppCount = await master.Applications.CountAsync();
+                initialProjectCount = await master.Projects.CountAsync();
+
+                Assert.NotNull(await master.Applications.SingleOrDefaultAsync(a => a.Name == "VS Code"));
+            }
+
+
+
+            using (var actScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = actScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                // ----------------------------------------
+                // LOAD LOG (simulate it being fetched somewhere else)
+                // ----------------------------------------
+                var incomingLog = (CodingLOG)await master.Logs
+                .Include(l => l.Author)
+                .Include(l => l.Application)
+                .Include(l => l.Project)
+                .Include(l => l.Output)
+                .Include(l => l.Type)
+                .Include(l => l.PostItList)
+                    .ThenInclude(p => p.Subject)
+                .FirstAsync(l => l.ID == originalLog.ID);
+
+                // ----------------------------------------
+                // DETACH
+                // ----------------------------------------
+                master.ChangeTracker.Clear();
+
+                // ----------------------------------------
+                // APPLY EDITOR CHANGES (now working on detached object)
+                // ----------------------------------------
+
+                await TesterUpdateCommandAsync(incomingLog, master, editorApplicationText,
+                    editorProjectText, incomingLog.accountID);
+
+
+                // Retrieve Dependency
+                var handler = serviceProvider.GetRequiredService<EntityHandler>();
+
+                // Update Log
+                await handler.UpdateLogAsync(incomingLog);
+            }
+
+
+
+            using (var assertScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = assertScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                var result = (CodingLOG)await master.Logs
+                .Include(l => l.Author)
+                .Include(l => l.Application)
+                .Include(l => l.Project)
+                .Include(l => l.Output)
+                .Include(l => l.Type)
+                .Include(l => l.PostItList)
+                    .ThenInclude(p => p.Subject)
+                .FirstAsync(l => l.ID == originalLog.ID);
+
+                // App changed
+                Assert.NotEqual(app1.Name, result.Application.Name);
+                Assert.NotEqual(app1.appID, result.appID);
+                Assert.Equal(app2.Name, result.Application.Name);
+
+                // App count hasn't changed
+                int appCount = await master.Applications.CountAsync();
+                Assert.True(initialAppCount == appCount);
+
+                // Project changed
+                Assert.Equal(project2.Name, result.Project.Name);
+
+                // Project's app uses the new existing app
+                Assert.Equal(result.Project.appID, result.appID);
+                Assert.Equal(app2.appID, result.appID);
+                Assert.NotEqual(app1.appID, result.appID);
+
+                // A new project has been added. Count should be higher
+                int projectCount = await master.Projects.CountAsync();
+                Assert.True(initialProjectCount < projectCount);
+
+                // Project ID changes and should not match project1 but project2.
+                Assert.NotEqual(project1.projectID, result.projectID);
+            }
+        }
+
+
+
+
         /// <summary>
         /// #1 + #A3
         /// Test the updating of application in the log to an existing application with an 
@@ -509,7 +581,7 @@ namespace DataLoggerTest
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task UpdateLogAsync_Should_Change_App_To_NEW_Existing_App_AND_Project_Unchanged()
+        public async Task UpdateLogAsync_SwitchToExistingAppAndProjectUnchanged()
         {
             var services = new ServiceCollection();
 
@@ -577,77 +649,8 @@ namespace DataLoggerTest
                 // APPLY EDITOR CHANGES (now working on detached object)
                 // ----------------------------------------
 
-                // APPLICATION
-
-                bool appIsNew = false;
-                var account = incomingLog.Author;
-
-                if (incomingLog.Application.Name != editorApplicationText)
-                {
-                    // App may be the same or changed. Changed app may be new or existing
-                    var app = await master.Applications.FirstOrDefaultAsync(a =>
-                        a.Name == editorApplicationText);
-
-                    if (app == null)
-                    {
-                        app = new ApplicationClass(editorApplicationText);
-                        app.accountID = account.accountID;
-                    }
-
-                    appIsNew = app.appID == 0;
-
-                    if (appIsNew)
-                        Assert.Fail("Application should be existing.");
-                    else
-                    {
-                        incomingLog.appID = app.appID;
-                        incomingLog.Application = null;
-                    }
-                }
-
-                // PROJECT
-
-                if (!appIsNew)
-                {
-                    bool projectBelongsToNewApp = incomingLog.Project.appID == incomingLog.appID;
-
-                    if (string.IsNullOrEmpty(editorProjectText))
-                    {
-                        // Set to "Unnamed Project" default
-                        incomingLog.projectID = 1;
-                        incomingLog.Project = null;
-                    }
-                    else if (incomingLog.Project!.Name != editorProjectText || !projectBelongsToNewApp)
-                    {
-                        // Find the project by Name AND the NEW App ID
-                        var project = await master.Projects.FirstOrDefaultAsync(p =>
-                            p.Name == editorProjectText && p.appID == incomingLog.appID);
-
-                        if (project == null)
-                        {
-                            project = new ProjectClass(editorProjectText);
-                            project.accountID = account.accountID;
-                            project.appID = incomingLog.appID;
-                        }
-
-                        if (project.projectID == 0)
-                        {
-                            incomingLog.Project = project;
-                        }
-                        else
-                        {
-                            incomingLog.projectID = project.projectID;
-                            incomingLog.Project = null;
-                        }
-                    }
-
-                }
-                else
-                {
-                    Assert.Fail("Application should be existing.");
-                }
-
-
+                await TesterUpdateCommandAsync(incomingLog, master, editorApplicationText,
+                    editorProjectText, incomingLog.accountID);
 
                 // Retrieve Dependency
                 var handler = serviceProvider.GetRequiredService<EntityHandler>();
@@ -714,130 +717,12 @@ namespace DataLoggerTest
 
 
         /// <summary>
-        /// Test the updating of application in the log to an existing application.
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public async Task UpdateLogAsync_Should_Change_App_To_NEW_App()
-        {
-            var services = new ServiceCollection();
-
-            // In memory database
-            services.AddDbContext<EntityMaster>(options => options.UseInMemoryDatabase(GetTestDbName()));
-
-            // Writer
-            services.AddScoped((services) => new EntityWriter(services));
-
-            // Handler
-            services.AddScoped((services) => new EntityHandler(services));
-
-            var serviceProvider = services.BuildServiceProvider();
-
-            CodingLOG originalLog;
-            const string editorApplicationText = "Komodo IDE";
-            const string editorProjectText = "Project Delta";
-
-            using (var seedScope = serviceProvider.CreateAsyncScope())
-            {
-                var master = seedScope.ServiceProvider.GetRequiredService<EntityMaster>();
-                originalLog = await SeedTestDataAsync(master);
-            }
-
-
-            using (var actScope = serviceProvider.CreateAsyncScope())
-            {
-                var master = actScope.ServiceProvider.GetRequiredService<EntityMaster>();
-
-                // ----------------------------------------
-                // LOAD LOG (simulate it being fetched somewhere else)
-                // ----------------------------------------
-                var incomingLog = (CodingLOG)await master.Logs
-                .Include(l => l.Author)
-                .Include(l => l.Application)
-                .Include(l => l.Project)
-                .Include(l => l.Output)
-                .Include(l => l.Type)
-                .Include(l => l.PostItList)
-                    .ThenInclude(p => p.Subject)
-                .FirstAsync(l => l.ID == originalLog.ID);
-
-                // ----------------------------------------
-                // DETACH
-                // ----------------------------------------
-                master.ChangeTracker.Clear();
-
-                // ----------------------------------------
-                // APPLY EDITOR CHANGES (now working on detached object)
-                // ----------------------------------------
-
-                // Parent updates
-                // APPLICATION
-
-                bool appIsNew = false;
-                var account = incomingLog.Author;
-
-                if (incomingLog.Application.Name != editorApplicationText)
-                {
-                    // App may be the same or changed. Changed app may be new or existing
-                    var app = await master.Applications.FirstOrDefaultAsync(a =>
-                        a.Name == editorApplicationText);
-
-                    if (app == null)
-                    {
-                        app = new ApplicationClass(editorApplicationText);
-                        app.accountID = account.accountID;
-                    }
-
-                    appIsNew = app.appID == 0;
-
-                    if (appIsNew)
-                        incomingLog.Application = app;
-                    else
-                    {
-                        incomingLog.appID = app.appID;
-                        incomingLog.Application = null;
-                    }
-                }
-
-
-
-                // Retrieve Dependency
-                var handler = serviceProvider.GetRequiredService<EntityHandler>();
-
-                // Update Log
-                await handler.UpdateLogAsync(incomingLog);
-            }
-
-
-            using (var assertScope = serviceProvider.CreateAsyncScope())
-            {
-                var master = assertScope.ServiceProvider.GetRequiredService<EntityMaster>();
-
-                var result = (CodingLOG)await master.Logs
-                .Include(l => l.Author)
-                .Include(l => l.Application)
-                .Include(l => l.Project)
-                .Include(l => l.Output)
-                .Include(l => l.Type)
-                .Include(l => l.PostItList)
-                    .ThenInclude(p => p.Subject)
-                .FirstAsync(l => l.ID == originalLog.ID);
-
-                // Parent scalar/nav assertions
-                Assert.Equal(editorApplicationText, result.Application.Name);
-            }
-        }
-
-
-
-
-        /// <summary>
         /// #2 + #A2
         /// Test the updating of a project to a NEW project in the log with a NEW application.
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task UpdateLogAsync_Should_Change_Project_To_NEW_Project_AND_NEW_App()
+        public async Task UpdateLogAsync_SwitchToNewAppAndNewProject()
         {
             var services = new ServiceCollection();
 
@@ -893,42 +778,8 @@ namespace DataLoggerTest
                 // APPLY EDITOR CHANGES (now working on detached object)
                 // ----------------------------------------
 
-                // Parent updates
-                // APPLICATION
-
-                bool appIsNew = false;
-                var account = incomingLog.Author;
-
-                if (incomingLog.Application.Name != editorApplicationText)
-                {
-                    // App may be the same or changed. Changed app may be new or existing
-                    var app = await master.Applications.FirstOrDefaultAsync(a =>
-                        a.Name == editorApplicationText);
-
-                    if (app == null)
-                    {
-                        app = new ApplicationClass(editorApplicationText);
-                        app.accountID = account.accountID;
-                    }
-
-                    appIsNew = app.appID == 0;
-
-                    if (appIsNew)
-                        incomingLog.Application = app;
-                    else
-                    {
-                        incomingLog.appID = app.appID;
-                        incomingLog.Application = null;
-                    }
-                }
-
-
-                // PROJECT
-
-                // App shud be new
-                Assert.True(appIsNew);
-
-                incomingLog.Project = new ProjectClass(account, editorProjectText, incomingLog.Application!);
+                await TesterUpdateCommandAsync(incomingLog, master, editorApplicationText,
+                    editorProjectText, incomingLog.accountID);
 
                 // Retrieve Dependency
                 var handler = serviceProvider.GetRequiredService<EntityHandler>();
@@ -990,13 +841,13 @@ namespace DataLoggerTest
 
 
         /// <summary>
-        /// #3 + #A2
-        /// Test the updating of a project to a new project in the log with an existing 
+        /// #3 + #A1
+        /// Test the updating of a project to an existing project in the log with an unchanged
         /// application.
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task UpdateLogAsync_Should_Change_Project_To_NEW_Project_AND_App_Unchanged()
+        public async Task UpdateLogAsync_SwitchToUnchangedAppAndExistingProject()
         {
             var services = new ServiceCollection();
 
@@ -1013,16 +864,24 @@ namespace DataLoggerTest
 
             CodingLOG originalLog;
             string editorApplicationText = string.Empty;
-            const string editorProjectText = "Project Delta";
+            string editorProjectText = string.Empty;
             int initialProjectCount = 0;
 
-            ApplicationClass app1;
+            ApplicationClass? app1;
+            ProjectClass project1, project2;
 
             using (var seedScope = serviceProvider.CreateAsyncScope())
             {
                 var master = seedScope.ServiceProvider.GetRequiredService<EntityMaster>();
                 originalLog = await SeedTestDataAsync(master);
-                app1 = originalLog.Application;
+                app1 = await master.Applications.FirstOrDefaultAsync(a => a.appID == originalLog.appID);
+                project1 = originalLog.Project;
+                project2 = new ProjectClass(originalLog.Author, "Project Beta", app1);
+                editorApplicationText = app1.Name;
+                editorProjectText = project2.Name;
+                await master.Projects.AddAsync(project2);
+                await master.SaveChangesAsync();
+
                 initialProjectCount = await master.Projects.CountAsync();
             }
 
@@ -1054,73 +913,116 @@ namespace DataLoggerTest
                 // APPLY EDITOR CHANGES (now working on detached object)
                 // ----------------------------------------
 
-                // Parent updates
-                // APPLICATION
+                await TesterUpdateCommandAsync(incomingLog, master, editorApplicationText,
+                    editorProjectText, incomingLog.accountID);
 
-                bool appIsNew = false;
+                // Retrieve Dependency
+                var handler = serviceProvider.GetRequiredService<EntityHandler>();
+
+                // Update Log
+                await handler.UpdateLogAsync(incomingLog);
+            }
+
+            using (var assertScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = assertScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                var result = (CodingLOG)await master.Logs
+                .Include(l => l.Author)
+                .Include(l => l.Application)
+                .Include(l => l.Project)
+                .Include(l => l.Output)
+                .Include(l => l.Type)
+                .Include(l => l.PostItList)
+                    .ThenInclude(p => p.Subject)
+                .FirstAsync(l => l.ID == originalLog.ID);
+
+                // Project Changed to New Existing
+                Assert.Equal(editorProjectText, result.Project.Name);
+                Assert.NotEqual(originalLog.Project.Name, result.Project.Name);
+                Assert.Equal(project2.projectID, result.projectID);
+
+                // Project Count NOT Changed
+                int projectsCount = await master.Projects.CountAsync();
+                Assert.True(initialProjectCount == projectsCount);
+
+                // App Unchanged
+                Assert.Equal(app1.Name, result.Application.Name);
+                Assert.Equal(originalLog.appID, result.appID);
+                Assert.Equal(result.Project.appID, result.appID);
+            }
+        }
+
+
+
+        /// <summary>
+        /// #3 + #A2
+        /// Test the updating of a project to a new project in the log with an existing 
+        /// application.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task UpdateLogAsync_SwitchToUnchangedAppAndNewProject()
+        {
+            var services = new ServiceCollection();
+
+            // In memory database
+            services.AddDbContext<EntityMaster>(options => options.UseInMemoryDatabase(GetTestDbName()));
+
+            // Writer
+            services.AddScoped((services) => new EntityWriter(services));
+
+            // Handler
+            services.AddScoped((services) => new EntityHandler(services));
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            CodingLOG originalLog;
+            string editorApplicationText = string.Empty;
+            const string editorProjectText = "Project Delta";
+            int initialProjectCount = 0;
+
+            ApplicationClass app1;
+
+            using (var seedScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = seedScope.ServiceProvider.GetRequiredService<EntityMaster>();
+                originalLog = await SeedTestDataAsync(master);
+                app1 = originalLog.Application;
                 editorApplicationText = app1.Name;
-                var account = incomingLog.Author;
+                initialProjectCount = await master.Projects.CountAsync();
+            }
 
-                if (incomingLog.Application.Name != editorApplicationText)
-                {
-                    // App may be the same or changed. Changed app may be new or existing
-                    var app = await master.Applications.FirstOrDefaultAsync(a =>
-                        a.Name == editorApplicationText);
 
-                    if (app == null)
-                    {
-                        app = new ApplicationClass(editorApplicationText);
-                        app.accountID = account.accountID;
-                    }
 
-                    appIsNew = app.appID == 0;
+            using (var actScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = actScope.ServiceProvider.GetRequiredService<EntityMaster>();
 
-                    if (appIsNew)
-                        incomingLog.Application = app;
-                    else
-                    {
-                        incomingLog.appID = app.appID;
-                        incomingLog.Application = null;
-                    }
-                }
+                // ----------------------------------------
+                // LOAD LOG (simulate it being fetched somewhere else)
+                // ----------------------------------------
+                var incomingLog = (CodingLOG)await master.Logs
+                    .Include(l => l.Author)
+                    .Include(l => l.Application)
+                    .Include(l => l.Project)
+                    .Include(l => l.Output)
+                    .Include(l => l.Type)
+                    .Include(l => l.PostItList)
+                        .ThenInclude(p => p.Subject)
+                    .FirstAsync(l => l.ID == originalLog.ID);
 
-                // PROJECT
+                // ----------------------------------------
+                // DETACH
+                // ----------------------------------------
+                master.ChangeTracker.Clear();
 
-                if (!appIsNew)
-                {
-                    bool projectBelongsToNewApp = incomingLog.Project.appID == incomingLog.appID;
+                // ----------------------------------------
+                // APPLY EDITOR CHANGES (now working on detached object)
+                // ----------------------------------------
 
-                    if (string.IsNullOrEmpty(editorProjectText))
-                    {
-                        // Set to "Unnamed Project" default
-                        incomingLog.projectID = 1;
-                        incomingLog.Project = null;
-                    }
-                    else if (incomingLog.Project!.Name != editorProjectText || !projectBelongsToNewApp)
-                    {
-                        // Find the project by Name AND the NEW App ID
-                        var project = await master.Projects.FirstOrDefaultAsync(p =>
-                            p.Name == editorProjectText && p.appID == incomingLog.appID);
-
-                        if (project == null)
-                        {
-                            project = new ProjectClass(editorProjectText);
-                            project.accountID = account.accountID;
-                            project.appID = incomingLog.appID;
-                        }
-
-                        if (project.projectID == 0)
-                        {
-                            incomingLog.Project = project;
-                        }
-                        else
-                        {
-                            incomingLog.projectID = project.projectID;
-                            incomingLog.Project = null;
-                        }
-                    }
-
-                }
+                await TesterUpdateCommandAsync(incomingLog, master, editorApplicationText,
+                    editorProjectText, incomingLog.accountID);
 
                 // Retrieve Dependency
                 var handler = serviceProvider.GetRequiredService<EntityHandler>();
@@ -1160,6 +1062,108 @@ namespace DataLoggerTest
 
 
 
+
+        /// <summary>
+        /// #3 + #A3
+        /// Test the updating of a project to an unchanged project in the log with an unchanged
+        /// application.
+        /// </summary>
+        [Fact]
+        public async Task UpdateLogAsync_SwitchToUnchangedAppAndUnchangedProject()
+        {
+            var services = new ServiceCollection();
+
+            services.AddDbContext<EntityMaster>(options => options.UseInMemoryDatabase(GetTestDbName()));
+            services.AddScoped((services) => new EntityWriter(services));
+            services.AddScoped((services) => new EntityHandler(services));
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            CodingLOG originalLog;
+            string editorApplicationText = string.Empty;
+            string editorProjectText = string.Empty;
+            int initialAppCount = 0;
+            int initialProjectCount = 0;
+
+            ApplicationClass app1;
+            ProjectClass project1;
+
+            using (var seedScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = seedScope.ServiceProvider.GetRequiredService<EntityMaster>();
+                originalLog = await SeedTestDataAsync(master);
+
+                app1 = originalLog.Application;
+                project1 = originalLog.Project;
+
+                editorApplicationText = app1.Name;
+                editorProjectText = project1.Name;
+                initialAppCount = await master.Applications.CountAsync();
+                initialProjectCount = await master.Projects.CountAsync();
+            }
+
+            using (var actScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = actScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                var incomingLog = (CodingLOG)await master.Logs
+                    .Include(l => l.Author)
+                    .Include(l => l.Application)
+                    .Include(l => l.Project)
+                    .Include(l => l.Output)
+                    .Include(l => l.Type)
+                    .Include(l => l.PostItList)
+                        .ThenInclude(p => p.Subject)
+                    .FirstAsync(l => l.ID == originalLog.ID);
+
+                master.ChangeTracker.Clear();
+
+                await TesterUpdateCommandAsync(
+                    incomingLog,
+                    master,
+                    editorApplicationText,
+                    editorProjectText,
+                    incomingLog.accountID);
+
+                var handler = serviceProvider.GetRequiredService<EntityHandler>();
+                await handler.UpdateLogAsync(incomingLog);
+            }
+
+            using (var assertScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = assertScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                var result = (CodingLOG)await master.Logs
+                    .Include(l => l.Author)
+                    .Include(l => l.Application)
+                    .Include(l => l.Project)
+                    .Include(l => l.Output)
+                    .Include(l => l.Type)
+                    .Include(l => l.PostItList)
+                        .ThenInclude(p => p.Subject)
+                    .FirstAsync(l => l.ID == originalLog.ID);
+
+                // App unchanged
+                Assert.Equal(app1.appID, result.appID);
+                Assert.Equal(result.Project.appID, result.appID);
+
+                // App count unchanged
+                int appCount = await master.Applications.CountAsync();
+                Assert.Equal(initialAppCount, appCount);
+
+                // Project unchanged
+                Assert.Equal(project1.Name, result.Project.Name);
+                Assert.Equal(project1.projectID, result.projectID);
+
+                // Project count unchanged
+                int projectsCount = await master.Projects.CountAsync();
+                Assert.Equal(initialProjectCount, projectsCount);
+
+            }
+        }
+
+
+
         #endregion
 
 
@@ -1167,7 +1171,324 @@ namespace DataLoggerTest
 
 
 
+        #region POST ITS
 
+
+
+        public static IEnumerable<object[]> LogTestCases()
+        {
+            var account = new ACCOUNT
+            {
+                accountID = 1,
+                FirstName = "Ninja",
+                LastName = "Dev",
+                Email = "ninja@test.com",
+                Password = "test123",
+                ProfilePic = "/Assets/login/user.png"
+            };
+
+            // ---------- ADD ----------
+            {
+
+                var app = new ApplicationClass(account, "Visual Studio");
+                var project = new ProjectClass(account, "Project Alpha", app);
+
+                var subject = new SubjectClass(
+                    LOG.CATEGORY.CODING,
+                    account,
+                    "Existing Subject",
+                    project,
+                    app
+                );
+
+                yield return new object[]
+                {
+                    "Add PostIt",
+
+                    account,
+                    new List<ApplicationClass> { app },
+                    new List<ProjectClass> { project },
+                    new List<SubjectClass> { subject },
+
+                    new List<PostIt>
+                    {
+                        new PostIt
+                        {
+                            Subject = subject,
+                            subjectID = subject.subjectID,
+                            accountID = account.accountID,
+                            Error = "Old"
+                        }
+                    },
+
+                    new List<PostItEditorInput>
+                    {
+                        new PostItEditorInput
+                        {
+                            ID = 1,
+                            SubjectText = "Existing Subject",
+                            Error = "Old"
+                        },
+                        new PostItEditorInput
+                        {
+                            ID = 0,
+                            SubjectText = "New Subject",
+                            Error = "New"
+                        }
+                    },
+
+                    (Action<CodingLOG>)(result =>
+                    {
+                        Assert.Equal(2, result.PostItList.Count);
+                        Assert.Contains(result.PostItList, p => p.Error == "New");
+                    })
+                };
+            }
+
+            // ---------- UPDATE ----------
+            {
+                var app = new ApplicationClass(account, "Visual Studio");
+                var project = new ProjectClass(account, "Project Alpha", app);
+
+                var subject = new SubjectClass(
+                    LOG.CATEGORY.CODING,
+                    account,
+                    "Existing Subject",
+                    project,
+                    app
+                );
+
+                yield return new object[]
+                {
+                    "Update PostIt",
+
+                    account,
+                    new List<ApplicationClass> { app },
+                    new List<ProjectClass> { project },
+                    new List<SubjectClass> { subject },
+
+                    new List<PostIt>
+                    {
+                        new PostIt
+                        {
+                            postItID = 1,
+                            Subject = subject,
+                            subjectID = subject.subjectID,
+                            accountID = account.accountID,
+                            Error = "Old"
+                        }
+                    },
+
+                    new List<PostItEditorInput>
+                    {
+                        new PostItEditorInput
+                        {
+                            ID = 1,
+                            SubjectText = "Existing Subject",
+                            Error = "Updated"
+                        }
+                    },
+
+                    (Action<CodingLOG>)(result =>
+                    {
+                        Assert.Single(result.PostItList);
+                        Assert.Contains(result.PostItList, p => p.Error == "Updated");
+                    })
+                };
+            }
+
+            // ---------- DELETE ----------
+            {
+
+                var app = new ApplicationClass(account, "Visual Studio");
+                var project = new ProjectClass(account, "Project Alpha", app);
+
+                var subjectA = new SubjectClass(
+                    LOG.CATEGORY.CODING,
+                    account,
+                    "A",
+                    project,
+                    app
+                );
+
+                var subjectB = new SubjectClass(
+                    LOG.CATEGORY.CODING,
+                    account,
+                    "B",
+                    project,
+                    app
+                );
+
+                yield return new object[]
+                        {
+                    "Delete PostIt",
+
+                    account,
+                    new List<ApplicationClass> { app },
+                    new List<ProjectClass> { project },
+                    new List<SubjectClass> { subjectA, subjectB },
+
+                    new List<PostIt>
+                    {
+                        new PostIt
+                        {
+                            postItID = 1,
+                            Subject = subjectA,
+                            subjectID = subjectA.subjectID,
+                            accountID = account.accountID,
+                            Error = "Keep"
+                        },
+                        new PostIt
+                        {
+                            postItID = 2,
+                            Subject = subjectB,
+                            subjectID = subjectB.subjectID,
+                            accountID = account.accountID,
+                            Error = "Delete"
+                        }
+                    },
+
+                    new List<PostItEditorInput>
+                    {
+                        new PostItEditorInput
+                        {
+                            ID = 1,
+                            SubjectText = "A",
+                            Error = "Keep"
+                        }
+                    },
+
+                    (Action<CodingLOG>)(result =>
+                    {
+                        Assert.Single(result.PostItList);
+                        Assert.DoesNotContain(result.PostItList, p => p.Error == "Delete");
+                    })
+                };
+            }
+        }
+
+
+
+
+
+        /// <summary>
+        /// Test PostIt cases
+        /// </summary>
+        /// <returns></returns>
+        [Theory]
+        [MemberData(nameof(LogTestCases))]
+        public async Task UpdateLogAsync_PostIts_Cases(
+            string caseName,
+            ACCOUNT account,
+            List<ApplicationClass> apps,
+            List<ProjectClass> projects,
+            List<SubjectClass> subjects,
+            List<PostIt> seedPostIts,
+            List<PostItEditorInput> inputs,
+            Action<CodingLOG> assertAction)
+        {
+            var services = new ServiceCollection();
+
+            var dbName = $"TestDB_{caseName}_{GetTestDbName()}";
+            services.AddDbContext<EntityMaster>(options => options.UseInMemoryDatabase(dbName));
+
+            services.AddScoped((s) => new EntityWriter(s));
+            services.AddScoped((s) => new EntityHandler(s));
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            CodingLOG originalLog;
+
+            using (var seedScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = seedScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                originalLog = await SeedTestDataAsync(
+                    master,
+                    account,
+                    apps,
+                    projects,
+                    subjects,
+                    seedPostIts
+                );
+
+                Assert.NotEmpty(await master.Logs.ToListAsync());
+            }
+
+            using (var actScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = actScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                var incomingLog = (CodingLOG)await master.Logs
+                    .Include(l => l.Author)
+                    .Include(l => l.Application)
+                    .Include(l => l.Project)
+                    .Include(l => l.PostItList)
+                        .ThenInclude(p => p.Subject)
+                    .FirstAsync(l => l.ID == originalLog.ID);
+
+                master.ChangeTracker.Clear();
+
+                // App + Project logic
+                await TesterUpdateCommandAsync(
+                    incomingLog,
+                    master,
+                    incomingLog.Application.Name,
+                    incomingLog.Project.Name,
+                    incomingLog.accountID
+                );
+
+                // PostIt logic
+                await TesterPostItUpdateCommandAsync(
+                    incomingLog,
+                    master,
+                    incomingLog.Application,
+                    incomingLog.Project,
+                    inputs
+                );
+
+                Console.WriteLine("=== BEFORE UPDATE ===");
+                DumpLog(incomingLog);
+
+                var handler = serviceProvider.GetRequiredService<EntityHandler>();
+                await handler.UpdateLogAsync(incomingLog);
+            }
+
+            using (var assertScope = serviceProvider.CreateAsyncScope())
+            {
+                var master = assertScope.ServiceProvider.GetRequiredService<EntityMaster>();
+
+                var result = (CodingLOG)await master.Logs
+                    .Include(l => l.Author)
+                    .Include(l => l.Application)
+                    .Include(l => l.Project)
+                    .Include(l => l.PostItList)
+                        .ThenInclude(p => p.Subject)
+                    .FirstAsync(l => l.ID == originalLog.ID);
+
+                Console.WriteLine("=== AFTER UPDATE ===");
+                DumpLog(result);
+
+                assertAction(result);
+            }
+        }
+
+
+
+
+
+        #endregion
+
+        void DumpLog(CodingLOG log)
+        {
+            Console.WriteLine($"Log ID: {log.ID}");
+            Console.WriteLine($"PostIts count: {log.PostItList.Count}");
+
+            foreach (var p in log.PostItList)
+            {
+                Console.WriteLine($"- ID: {p.postItID}, Error: {p.Error}");
+            }
+        }
 
 
 

--- a/DLSTests/READERFinderTests.cs
+++ b/DLSTests/READERFinderTests.cs
@@ -3,7 +3,7 @@ using Data_Logger_1._3.Models.App_Models;
 using Data_Logger_1._3.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace DataLoggerTest
+namespace DLSTests
 {
     public class READERFinderTests : ENTITYMASTERTests
     {

--- a/DLSTests/READERListTests.cs
+++ b/DLSTests/READERListTests.cs
@@ -2,7 +2,7 @@
 using Data_Logger_1._3.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace DataLoggerTest
+namespace DLSTests
 {
     public class READERListTests
     {

--- a/DLSTests/WRITERLogTests.cs
+++ b/DLSTests/WRITERLogTests.cs
@@ -3,7 +3,7 @@ using Data_Logger_1._3.Models.App_Models;
 using Data_Logger_1._3.Services;
 using Microsoft.EntityFrameworkCore;
 
-namespace DataLoggerTest
+namespace DLSTests
 {
     public class WRITERLogTests : ENTITYMASTERTests
     {

--- a/Models/App Models/SubjectClass.cs
+++ b/Models/App Models/SubjectClass.cs
@@ -25,11 +25,11 @@ namespace Data_Logger_1._3.Models.App_Models
 
         public string Subject { get; set; } = "";
 
-        public int projectID { get; set; } = 1;
+        public int projectID { get; set; }
         public ProjectClass Project { get; set; }
 
 
-        public int appID { get; set; } = 3;
+        public int appID { get; set; }
         public ApplicationClass Application { get; set; }
 
         public SubjectClass()

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -642,9 +642,9 @@ namespace Data_Logger_1._3.Services
         /// <summary>
         /// Finds a subject by its name and category.
         /// </summary>
-        public Task<SubjectClass?> FindSubject(string subject, LOG.CATEGORY category)
+        public Task<SubjectClass?> FindSubject(string subject, LOG.CATEGORY category, int appID, int projectID)
         {
-            return UseReaderAsync(reader => reader.FindSubject(subject, category));
+            return UseReaderAsync(reader => reader.FindSubject(subject, category, appID, projectID));
         }
 
         /// <summary>

--- a/Services/ENTITYHANDLER.cs
+++ b/Services/ENTITYHANDLER.cs
@@ -86,7 +86,7 @@ namespace Data_Logger_1._3.Services
                 if (log.Output != null)
                     existingLog.Output = master.Outputs
                         .FirstOrDefault(o => o.outputID == log.Output.outputID) ?? log.Output;
-
+                
                 if (log.Type != null)
                     existingLog.Type = master.Types
                         .FirstOrDefault(t => t.typeID == log.Type.typeID) ?? log.Type;

--- a/Services/ENTITYHANDLER.cs
+++ b/Services/ENTITYHANDLER.cs
@@ -67,6 +67,10 @@ namespace Data_Logger_1._3.Services
                         existingLog.Application = log.Application;
                     }
                 }
+                else
+                {
+                    existingLog.Application = await master.Applications.FirstOrDefaultAsync(a => a.appID == existingLog.appID);
+                }
 
 
                 // PROJECT
@@ -82,11 +86,15 @@ namespace Data_Logger_1._3.Services
                     log.Project.Application = existingLog.Application!;
                     existingLog.Project = log.Project;
                 }
+                else
+                {
+                    existingLog.Project = await master.Projects.FirstOrDefaultAsync(p => p.projectID == existingLog.projectID);
+                }
 
                 if (log.Output != null)
                     existingLog.Output = master.Outputs
                         .FirstOrDefault(o => o.outputID == log.Output.outputID) ?? log.Output;
-                
+
                 if (log.Type != null)
                     existingLog.Type = master.Types
                         .FirstOrDefault(t => t.typeID == log.Type.typeID) ?? log.Type;
@@ -130,8 +138,7 @@ namespace Data_Logger_1._3.Services
                     else
                     {
                         // Subject Exists
-                        trackedSubject = master.Subjects
-                            .FirstOrDefault(s => s.subjectID == postIt.subjectID);
+                        trackedSubject = master.Subjects.FirstOrDefault(s => s.subjectID == postIt.subjectID);
                     }
 
 

--- a/Services/ENTITYREADER.cs
+++ b/Services/ENTITYREADER.cs
@@ -853,7 +853,7 @@ namespace Data_Logger_1._3.Services
 
 
 
-        public async Task<SubjectClass?> FindSubject(string name, LOG.CATEGORY category)
+        public async Task<SubjectClass?> FindSubject(string name, LOG.CATEGORY category, int appID, int projectID)
         {
             await using var scope = _serviceProvider.CreateAsyncScope();
             var master = scope.ServiceProvider.GetRequiredService<EntityMaster>();
@@ -867,6 +867,8 @@ namespace Data_Logger_1._3.Services
                     .Where(s => new[] { 1, onlineUserID }.Contains(s.accountID))
                     .Where(s => s.Subject == name)
                     .Where(s => s.Category == category)
+                    .Where(s => s.projectID == projectID)
+                    .Where(s => s.appID == appID)
                     .FirstOrDefaultAsync();
             }
             catch (Exception ex)
@@ -877,7 +879,8 @@ namespace Data_Logger_1._3.Services
             return null;
         }
 
-        public async Task<SubjectClass?> FindSubject(AsyncServiceScope scope, EntityMaster master, string name, LOG.CATEGORY category)
+        public async Task<SubjectClass?> FindSubject(AsyncServiceScope scope, EntityMaster master, string name, LOG.CATEGORY category,
+            int appID, int projectID)
         {
             var writer = scope.ServiceProvider.GetRequiredService<EntityWriter>();
 
@@ -889,6 +892,8 @@ namespace Data_Logger_1._3.Services
                     .Where(s => new[] { 1, onlineUserID }.Contains(s.accountID))
                     .Where(s => s.Subject == name)
                     .Where(s => s.Category == category)
+                    .Where(s => s.projectID == projectID)
+                    .Where(s => s.appID == appID)
                     .FirstOrDefaultAsync();
             }
             catch (Exception ex)
@@ -898,6 +903,8 @@ namespace Data_Logger_1._3.Services
 
             return null;
         }
+
+
 
         /// <summary>
         /// Looks for a subject ID for the given SubjectClass.

--- a/Services/ENTITYWRITER.cs
+++ b/Services/ENTITYWRITER.cs
@@ -1,7 +1,5 @@
 ﻿using Data_Logger_1._3.Models;
-using Data_Logger_1._3.Models.App_Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using System.Data;
 using System.Diagnostics;
@@ -296,7 +294,7 @@ namespace Data_Logger_1._3.Services
                     postIt.Subject.Application = log.Application;
                     postIt.Subject.Project = log.Project;
 
-                    var existingSubject = await reader.FindSubject(scope, master, postIt.Subject.Subject, log.Category);
+                    var existingSubject = await reader.FindSubject(scope, master, postIt.Subject.Subject, log.Category, log.appID, log.projectID);
 
                     if (existingSubject != null)
                     {

--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -57,7 +57,7 @@ namespace Data_Logger_1._3.Services
         Task<OutputClass?> FindOutputByID(int outputID);
         Task<TypeClass?> FindType(string name);
         Task<TypeClass?> FindTypeByID(int typeID);
-        Task<SubjectClass?> FindSubject(string subject, LOG.CATEGORY category);
+        Task<SubjectClass?> FindSubject(string subject, LOG.CATEGORY category, int appID, int projectID);
         Task<int> FindSubjectID(SubjectClass subject);
 
         Task<List<OutputClass>?> ListQtOutputs();


### PR DESCRIPTION
Fixed inconsistencies when updating PostIts within a log, ensuring correct persistence across application, project, and subject relationships. Verified updates across multiple edge cases including existing and new entities as well as detach/reattach flows. Closes #12 #19 