### PR TITLE
fix: post it subject being duplicated in the database

### DIFF
--- a/Services/ENTITYREADER.cs
+++ b/Services/ENTITYREADER.cs
@@ -892,8 +892,8 @@ namespace Data_Logger_1._3.Services
                     .Where(s => new[] { 1, onlineUserID }.Contains(s.accountID))
                     .Where(s => s.Subject == name)
                     .Where(s => s.Category == category)
-                    .Where(s => s.projectID == projectID)
                     .Where(s => s.appID == appID)
+                    .Where(s => s.projectID == projectID)
                     .FirstOrDefaultAsync();
             }
             catch (Exception ex)

--- a/Services/ENTITYWRITER.cs
+++ b/Services/ENTITYWRITER.cs
@@ -290,15 +290,20 @@ namespace Data_Logger_1._3.Services
 
                 if (postIt.Subject != null)
                 {
-                    postIt.Subject.User = onlineUser;
-                    postIt.Subject.Application = log.Application;
-                    postIt.Subject.Project = log.Project;
+                    var appID = log.Application.appID;
+                    var projectID = log.Project.projectID;
 
-                    var existingSubject = await reader.FindSubject(scope, master, postIt.Subject.Subject, log.Category, log.appID, log.projectID);
+                    var existingSubject = await reader.FindSubject(scope, master, postIt.Subject.Subject, log.Category, appID, projectID);
 
                     if (existingSubject != null)
                     {
                         postIt.Subject = existingSubject;
+                    }
+                    else
+                    {
+                        postIt.Subject.User = onlineUser;
+                        postIt.Subject.Application = log.Application;
+                        postIt.Subject.Project = log.Project;
                     }
 
                     postIt.Author = onlineUser;


### PR DESCRIPTION
Fixes an issue where selecting an existing subject when creating a post it would result in duplicate subject entries being created in the database. Existing subjects are now correctly reused during log save. Closes #24 