### PR TITLE
chore: change assembly name to "Data Logger"

### DIFF
--- a/Data Logger 1.3.csproj
+++ b/Data Logger 1.3.csproj
@@ -8,6 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>AlphaBetaIcon.ico</ApplicationIcon>
+    <AssemblyName>Data Logger</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
The assembly name has been changed and the executable is correctly named as "Data Logger". Closes #26 